### PR TITLE
feat/use raw HTML for link nodes

### DIFF
--- a/src/application/use-cases/publish-site.test.ts
+++ b/src/application/use-cases/publish-site.test.ts
@@ -124,8 +124,11 @@ describe('PublishSiteUseCase', () => {
     const noteHtml = await fs.readFile(path.join(outputDir, 'nodes', `${note.id}.html`), 'utf8');
     expect(noteHtml).toContain('<pre>');
 
-    const linkHtml = await fs.readFile(path.join(outputDir, 'nodes', `${link.id}.html`), 'utf8');
-    expect(linkHtml).toContain('<a href="https://example.com"');
+    const linkHtml = await fs.readFile(
+      path.join(outputDir, 'nodes', `${link.id}.html`),
+      'utf8'
+    );
+    expect(linkHtml).toContain('<p>Example</p>');
 
     const tagHtml = await fs.readFile(
       path.join(outputDir, 'nodes', `${tag.id}.html`),

--- a/src/external/publishers/html-generator.ts
+++ b/src/external/publishers/html-generator.ts
@@ -6,6 +6,7 @@ import type {
 
 interface LinkData {
   url: string;
+  html?: string;
 }
 
 interface FlashcardData {
@@ -160,6 +161,12 @@ export class HTMLGenerator implements SiteGenerator {
     switch (node.type) {
       case 'link':
         if (this.isLinkData(node.data)) {
+          if (node.data.html) {
+            return `
+        <div class="link-content">
+            ${node.data.html}
+        </div>`;
+          }
           return `
         <div class="link-content">
             <a href="${this.escapeHtml(


### PR DESCRIPTION
## Summary
- render stored HTML for link nodes when generating site pages
- adjust publish tests for raw link HTML
- update create node tests to use crawler stub and revised link schema

## Testing
- `pnpm test --run`


------
https://chatgpt.com/codex/tasks/task_e_68a84bd8d7f4832a8c6a297304c9a741