### PR TITLE
fix: show node titles on published site

### DIFF
--- a/src/application/use-cases/publish-site.test.ts
+++ b/src/application/use-cases/publish-site.test.ts
@@ -92,6 +92,8 @@ describe('PublishSiteUseCase', () => {
     const index = await fs.readFile(path.join(outputDir, 'index.html'), 'utf8');
     expect(index).toContain('1 nodes published');
     expect(index).toContain(`nodes/${publicNote.id}.html`);
+    expect(index).toContain(publicNote.title);
+    expect(index).toContain(`<p class="node-id">${publicNote.id}</p>`);
     expect(index).not.toContain(privateNote.title);
   });
 
@@ -122,6 +124,8 @@ describe('PublishSiteUseCase', () => {
     expect(index).toContain('Flashcards');
 
     const noteHtml = await fs.readFile(path.join(outputDir, 'nodes', `${note.id}.html`), 'utf8');
+    expect(noteHtml).toContain(`<h1>${note.title}</h1>`);
+    expect(noteHtml).toContain(`<p class="node-id">${note.id}</p>`);
     expect(noteHtml).toContain('<pre>');
 
     const linkHtml = await fs.readFile(

--- a/src/external/publishers/html-generator.ts
+++ b/src/external/publishers/html-generator.ts
@@ -129,19 +129,20 @@ export class HTMLGenerator implements SiteGenerator {
             <a href="../index.html">← Back to Index</a>
         </nav>
     </header>
-    
+
     <main>
         <article class="node-detail">
             <div class="node-meta">
                 <span class="node-type">${node.type}</span>
                 <time>${node.createdAt.toLocaleDateString()}</time>
             </div>
-            
+
             <h1>${this.getNodeTitle(node)}</h1>
-            
+            <p class="node-id">${node.id}</p>
+
             ${this.renderNodeContent(node)}
         </article>
-        
+
         ${this.renderRelatedNodes(node, allNodes)}
     </main>
 </body>
@@ -153,6 +154,7 @@ export class HTMLGenerator implements SiteGenerator {
     <a href="nodes/${node.id}.html" class="node-card">
         <div class="node-type-badge">${node.type}</div>
         <h3>${this.getNodeTitle(node)}</h3>
+        <p class="node-id">${node.id}</p>
         <p>${this.getNodeSummary(node)}</p>
     </a>`;
   }
@@ -203,6 +205,11 @@ export class HTMLGenerator implements SiteGenerator {
   }
 
   private getNodeTitle(node: Node): string {
+    if (node.title && node.title.trim().length > 0) {
+      return this.escapeHtml(node.title);
+    }
+
+    // Fallback to previous heuristics if title is missing
     switch (node.type) {
       case 'link':
         if (this.isLinkData(node.data)) {
@@ -308,6 +315,12 @@ h2 { font-size: 1.8rem; margin: 2rem 0 1rem; }
   border-radius: 4px;
   font-size: 0.75rem;
   text-transform: uppercase;
+  margin-bottom: 0.5rem;
+}
+
+.node-id {
+  font-size: 0.75rem;
+  color: #666666;
   margin-bottom: 0.5rem;
 }
 


### PR DESCRIPTION
## Summary
- display node titles instead of truncated IDs in generated pages
- show node IDs as small metadata beneath titles
- test publishing to ensure titles and IDs render correctly

## Testing
- `pnpm exec vitest run`


------
https://chatgpt.com/codex/tasks/task_e_68a853214bdc832a8841c572f83057c3