### PR TITLE
fix: hide flashcard preview body

### DIFF
--- a/src/external/publishers/html-generator.ts
+++ b/src/external/publishers/html-generator.ts
@@ -151,12 +151,13 @@ export class HTMLGenerator implements SiteGenerator {
   }
 
   private renderNodeCard(node: Node): string {
+    const summary = this.getNodeSummary(node);
     return `
     <a href="nodes/${node.id}.html" class="node-card">
         <div class="node-type-badge">${node.type}</div>
         <h3>${this.getNodeTitle(node)}</h3>
         <p class="node-id">${node.id}</p>
-        <p>${this.getNodeSummary(node)}</p>
+        ${summary ? `<p>${summary}</p>` : ''}
     </a>`;
   }
 
@@ -247,9 +248,7 @@ export class HTMLGenerator implements SiteGenerator {
         }
         break;
       case 'flashcard':
-        if (this.isFlashcardData(node.data)) {
-          return `Q: ${node.data.front.slice(0, 100)}...`;
-        }
+        // Flashcards already use their title for the question, so no preview is needed
         break;
     }
     return '';


### PR DESCRIPTION
## Summary
- avoid rendering flashcard content in index previews
- skip summary generation for flashcard nodes

## Testing
- `pnpm install`
- `pnpm test --run`


------
https://chatgpt.com/codex/tasks/task_e_68a8626919f4832a9df707c287e4fa7c