### PR TITLE
feat: add ink-based TUI

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "type": "module",
   "scripts": {
     "kg": "tsx src/main.ts",
+    "tui": "tsx src/tui.tsx",
     "build": "tsc",
     "test": "vitest",
     "format": "prettier --write .",
@@ -28,12 +29,18 @@
     "inquirer-autocomplete-standalone": "0.8.1",
     "jsdom": "26.1.0",
     "marked": "^16.2.0",
-    "ollama": "0.5.17"
+    "ollama": "0.5.17",
+    "ink": "6.2.2",
+    "ink-select-input": "6.2.0",
+    "ink-text-input": "6.0.0",
+    "react": "19.1.1"
   },
   "devDependencies": {
     "@dotenvx/dotenvx": "1.49.0",
     "@types/jsdom": "21.1.7",
     "@types/node": "24.2.1",
+    "@types/react": "19.1.10",
+    "@types/react-dom": "19.1.7",
     "drizzle-kit": "0.31.4",
     "prettier": "3.6.2",
     "tsx": "4.20.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,15 @@ importers:
       drizzle-orm:
         specifier: 0.44.4
         version: 0.44.4(@libsql/client@0.15.12)
+      ink:
+        specifier: 6.2.2
+        version: 6.2.2(@types/react@19.1.10)(react@19.1.1)
+      ink-select-input:
+        specifier: 6.2.0
+        version: 6.2.0(ink@6.2.2(@types/react@19.1.10)(react@19.1.1))(react@19.1.1)
+      ink-text-input:
+        specifier: 6.0.0
+        version: 6.0.0(ink@6.2.2(@types/react@19.1.10)(react@19.1.1))(react@19.1.1)
       inquirer-autocomplete-standalone:
         specifier: 0.8.1
         version: 0.8.1
@@ -38,6 +47,9 @@ importers:
       ollama:
         specifier: 0.5.17
         version: 0.5.17
+      react:
+        specifier: 19.1.1
+        version: 19.1.1
     devDependencies:
       '@dotenvx/dotenvx':
         specifier: 1.49.0
@@ -48,6 +60,12 @@ importers:
       '@types/node':
         specifier: 24.2.1
         version: 24.2.1
+      '@types/react':
+        specifier: 19.1.10
+        version: 19.1.10
+      '@types/react-dom':
+        specifier: 19.1.7
+        version: 19.1.7(@types/react@19.1.10)
       drizzle-kit:
         specifier: 0.31.4
         version: 0.31.4
@@ -65,6 +83,10 @@ importers:
         version: 3.2.4(@types/node@24.2.1)(jsdom@26.1.0)(tsx@4.20.4)
 
 packages:
+
+  '@alcalzone/ansi-tokenize@0.2.0':
+    resolution: {integrity: sha512-qI/5TaaaCZE4yeSZ83lu0+xi1r88JSxUjnH4OP/iZF7+KKZ75u3ee5isd0LxX+6N8U0npL61YrpbthILHB6BnA==}
+    engines: {node: '>=18'}
 
   '@asamuzakjp/css-color@3.2.0':
     resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
@@ -748,6 +770,14 @@ packages:
   '@types/node@24.2.1':
     resolution: {integrity: sha512-DRh5K+ka5eJic8CjH7td8QpYEV6Zo10gfRkjHCO3weqZHWDtAaSTFtl4+VMqOJ4N5jcuhZ9/l+yy8rVgw7BQeQ==}
 
+  '@types/react-dom@19.1.7':
+    resolution: {integrity: sha512-i5ZzwYpqjmrKenzkoLM2Ibzt6mAsM7pxB6BCIouEVVmgiqaMj1TjaK7hnA36hbW5aZv20kx7Lw6hWzPWg0Rurw==}
+    peerDependencies:
+      '@types/react': ^19.0.0
+
+  '@types/react@19.1.10':
+    resolution: {integrity: sha512-EhBeSYX0Y6ye8pNebpKrwFJq7BoQ8J5SO6NlvNwwHjSj6adXJViPQrKlsyPw7hLBLvckEMO1yxeGdR82YBBlDg==}
+
   '@types/tough-cookie@4.0.5':
     resolution: {integrity: sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==}
 
@@ -797,17 +827,33 @@ packages:
     resolution: {integrity: sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==}
     engines: {node: '>=8'}
 
+  ansi-escapes@7.0.0:
+    resolution: {integrity: sha512-GdYO7a61mR0fOlAsvC9/rIHf7L96sBc6dEWzeOu+KAea5bZyQRPIpojrVoI4AXGJS/ycu/fBTdLrUkA4ODrvjw==}
+    engines: {node: '>=18'}
+
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
+
+  ansi-regex@6.2.0:
+    resolution: {integrity: sha512-TKY5pyBkHyADOPYlRT9Lx6F544mPl0vS5Ew7BJ45hA08Q+t3GjbueLliBWN3sMICk6+y7HdyxSzC4bWS8baBdg==}
+    engines: {node: '>=12'}
 
   ansi-styles@4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
 
+  ansi-styles@6.2.1:
+    resolution: {integrity: sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==}
+    engines: {node: '>=12'}
+
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
+
+  auto-bind@5.0.1:
+    resolution: {integrity: sha512-ooviqdwwgfIfNmDwo94wlshcdzfO64XV0Cg6oDsDYBJfITDz1EngD2z7DkbvCWn+XIMsIqW27sEVF6qcpJrRcg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
@@ -824,6 +870,10 @@ packages:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
 
+  chalk@5.6.0:
+    resolution: {integrity: sha512-46QrSQFyVSEyYAgQ22hQ+zDa60YHA4fBstHmtSApj1Y5vKtG27fWowW03jCk5KcbXEWPZUIR894aARCA/G1kfQ==}
+    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
+
   chardet@2.1.0:
     resolution: {integrity: sha512-bNFETTG/pM5ryzQ9Ad0lJOTa6HWD/YsScAR3EnCPZRPlQh77JocYktSHOUHelyhm8IARL+o4c4F1bP5KVOjiRA==}
 
@@ -831,13 +881,29 @@ packages:
     resolution: {integrity: sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==}
     engines: {node: '>= 16'}
 
+  cli-boxes@3.0.0:
+    resolution: {integrity: sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g==}
+    engines: {node: '>=10'}
+
+  cli-cursor@4.0.0:
+    resolution: {integrity: sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
   cli-spinners@2.9.2:
     resolution: {integrity: sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==}
     engines: {node: '>=6'}
 
+  cli-truncate@4.0.0:
+    resolution: {integrity: sha512-nPdaFdQ0h/GEigbPClz11D0v/ZJEwxmeVZGeMo3Z5StPtUTkA9o1lD6QwoirYiSDzbcwn2XcjwmCp68W1IS4TA==}
+    engines: {node: '>=18'}
+
   cli-width@4.1.0:
     resolution: {integrity: sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==}
     engines: {node: '>= 12'}
+
+  code-excerpt@4.0.0:
+    resolution: {integrity: sha512-xxodCmBen3iy2i0WtAK8FlFNrRzjUqjRsMfho58xT/wvZU1YTM3fCnRjcy1gJPMepaRlgm/0e6w8SpWHpn3/cA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
@@ -854,6 +920,10 @@ packages:
     resolution: {integrity: sha512-2uM9rYjPvyq39NwLRqaiLtWHyDC1FvryJDa2ATTVims5YAS4PupsEQsDvP14FqhFr0P49CYDugi59xaxJlTXRA==}
     engines: {node: '>=20'}
 
+  convert-to-spaces@2.0.1:
+    resolution: {integrity: sha512-rcQ1bsQO9799wq24uE5AM2tAILy4gXGIK/njFWcVQkGNZ96edlpY+A7bjwvzjYvLDyzmG1MmMLZhpcsb+klNMQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
@@ -861,6 +931,9 @@ packages:
   cssstyle@4.6.0:
     resolution: {integrity: sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==}
     engines: {node: '>=18'}
+
+  csstype@3.1.3:
+    resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
 
   data-uri-to-buffer@4.0.1:
     resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
@@ -994,6 +1067,9 @@ packages:
     resolution: {integrity: sha512-r6kEJXDKecVOCj2nLMuXK/FCPeurW33+3JRpfXVbjLja3XUYFfD9I/JBreH6sUyzcm3G/YQboBjMla6poKeSdA==}
     engines: {bun: '>=1', deno: '>=2', node: '>=16'}
 
+  emoji-regex@10.4.0:
+    resolution: {integrity: sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw==}
+
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
 
@@ -1001,8 +1077,15 @@ packages:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
     engines: {node: '>=0.12'}
 
+  environment@1.1.0:
+    resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
+    engines: {node: '>=18'}
+
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
+  es-toolkit@1.39.10:
+    resolution: {integrity: sha512-E0iGnTtbDhkeczB0T+mxmoVlT4YNweEKBLq7oaU4p11mecdsZpNWOglI4895Vh4usbQ+LsJiuLuI2L0Vdmfm2w==}
 
   esbuild-register@3.6.0:
     resolution: {integrity: sha512-H2/S7Pm8a9CL1uhp9OvjwrBh5Pvx0H8qVOxNu8Wed9Y7qv56MPtq+GGM8RJpq6glYJn9Wspr8uw7l55uyinNeg==}
@@ -1022,6 +1105,10 @@ packages:
   escape-string-regexp@1.0.5:
     resolution: {integrity: sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==}
     engines: {node: '>=0.8.0'}
+
+  escape-string-regexp@2.0.0:
+    resolution: {integrity: sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==}
+    engines: {node: '>=8'}
 
   escape-string-regexp@5.0.0:
     resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
@@ -1065,6 +1152,10 @@ packages:
     resolution: {integrity: sha512-ej8ksPF4x6e5wvK9yevct0UCXh8TTFlWGVLlgjZuoBH1HwjIfKE/IdL5mq89sFA7zELi1VhKpmtDnrs7zWyeyg==}
     engines: {node: '>=14'}
 
+  figures@6.1.0:
+    resolution: {integrity: sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==}
+    engines: {node: '>=18'}
+
   formdata-polyfill@4.0.10:
     resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
     engines: {node: '>=12.20.0'}
@@ -1073,6 +1164,10 @@ packages:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
+
+  get-east-asian-width@1.3.0:
+    resolution: {integrity: sha512-vpeMIQKxczTD/0s2CdEWHcb0eeJe6TFjxb+J5xgX7hScxqrGuyjmv4c1D4A/gelKfyox0gJJwIHF+fLjeaM8kQ==}
+    engines: {node: '>=18'}
 
   get-stream@6.0.1:
     resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
@@ -1109,6 +1204,37 @@ packages:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
 
+  indent-string@5.0.0:
+    resolution: {integrity: sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==}
+    engines: {node: '>=12'}
+
+  ink-select-input@6.2.0:
+    resolution: {integrity: sha512-304fZXxkpYxJ9si5lxRCaX01GNlmPBgOZumXXRnPYbHW/iI31cgQynqk2tRypGLOF1cMIwPUzL2LSm6q4I5rQQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      ink: '>=5.0.0'
+      react: '>=18.0.0'
+
+  ink-text-input@6.0.0:
+    resolution: {integrity: sha512-Fw64n7Yha5deb1rHY137zHTAbSTNelUKuB5Kkk2HACXEtwIHBCf9OH2tP/LQ9fRYTl1F0dZgbW0zPnZk6FA9Lw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      ink: '>=5'
+      react: '>=18'
+
+  ink@6.2.2:
+    resolution: {integrity: sha512-LN1f+/D8KKqMqRux08fIfA9wsEAJ9Bu9CiI3L6ih7bnqNSDUXT/JVJ0rUIc4NkjPiPaeI3BVNREcLYLz9ePSEg==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@types/react': '>=19.0.0'
+      react: '>=19.0.0'
+      react-devtools-core: ^4.19.1
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      react-devtools-core:
+        optional: true
+
   inquirer-autocomplete-standalone@0.8.1:
     resolution: {integrity: sha512-mlzwCTiXDX1Cw4yJL5PCq32k23XYLTK8K6BDFoL1a76iJeFB5ul6IoMU9spgdDagl2SM7P6ZaCNjj8VNXRDPOQ==}
     engines: {node: '>=16'}
@@ -1116,6 +1242,19 @@ packages:
   is-fullwidth-code-point@3.0.0:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
     engines: {node: '>=8'}
+
+  is-fullwidth-code-point@4.0.0:
+    resolution: {integrity: sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ==}
+    engines: {node: '>=12'}
+
+  is-fullwidth-code-point@5.0.0:
+    resolution: {integrity: sha512-OVa3u9kkBbw7b8Xw5F9P+D/T9X+Z4+JruYVNapTjPYZYUznQ5YfWeFkOj606XYYW8yugTfC8Pj0hYqvi4ryAhA==}
+    engines: {node: '>=18'}
+
+  is-in-ci@2.0.0:
+    resolution: {integrity: sha512-cFeerHriAnhrQSbpAxL37W1wcJKUUX07HyLWZCW1URJT/ra3GyUTzBgUnh24TMVfNTV2Hij2HLxkPHFZfOZy5w==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
@@ -1127,6 +1266,10 @@ packages:
   is-unicode-supported@1.3.0:
     resolution: {integrity: sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==}
     engines: {node: '>=12'}
+
+  is-unicode-supported@2.1.0:
+    resolution: {integrity: sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==}
+    engines: {node: '>=18'}
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
@@ -1225,6 +1368,10 @@ packages:
   parse5@7.3.0:
     resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
 
+  patch-console@2.0.0:
+    resolution: {integrity: sha512-0YNdUceMdaQwoKce1gatDScmMo5pu/tfABfnzEqeG0gtTmd7mh/WcwgUjtAeOU7N8nFFlbQBnFK2gXW5fGvmMA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
@@ -1259,12 +1406,26 @@ packages:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
+  react-reconciler@0.32.0:
+    resolution: {integrity: sha512-2NPMOzgTlG0ZWdIf3qG+dcbLSoAc/uLfOwckc3ofy5sSK0pLJqnQLpUFxvGcN2rlXSjnVtGeeFLNimCQEj5gOQ==}
+    engines: {node: '>=0.10.0'}
+    peerDependencies:
+      react: ^19.1.0
+
+  react@19.1.1:
+    resolution: {integrity: sha512-w8nqGImo45dmMIfljjMwOGtbmC/mk4CMYhWIicdSflH91J9TyCyczcPFXJzrZ/ZXcgGRFeP6BU0BEJTw6tZdfQ==}
+    engines: {node: '>=0.10.0'}
+
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
 
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
+  restore-cursor@4.0.0:
+    resolution: {integrity: sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   rollup@4.46.4:
     resolution: {integrity: sha512-YbxoxvoqNg9zAmw4+vzh1FkGAiZRK+LhnSrbSrSXMdZYsRPDWoshcSd/pldKRO6lWzv/e9TiJAVQyirYIeSIPQ==}
@@ -1285,6 +1446,9 @@ packages:
     resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
     engines: {node: '>=v12.22.7'}
 
+  scheduler@0.26.0:
+    resolution: {integrity: sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==}
+
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
     engines: {node: '>=8'}
@@ -1303,6 +1467,14 @@ packages:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
 
+  slice-ansi@5.0.0:
+    resolution: {integrity: sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ==}
+    engines: {node: '>=12'}
+
+  slice-ansi@7.1.0:
+    resolution: {integrity: sha512-bSiSngZ/jWeX93BqeIAbImyTbEihizcwNjFoRUIY/T1wWQsfsm2Vw1agPKylXvQTU7iASGdHhyqRlqQzfz+Htg==}
+    engines: {node: '>=18'}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
@@ -1314,6 +1486,10 @@ packages:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
 
+  stack-utils@2.0.6:
+    resolution: {integrity: sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==}
+    engines: {node: '>=10'}
+
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
@@ -1324,9 +1500,17 @@ packages:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
     engines: {node: '>=8'}
 
+  string-width@7.2.0:
+    resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
+    engines: {node: '>=18'}
+
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
+
+  strip-ansi@7.1.0:
+    resolution: {integrity: sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==}
+    engines: {node: '>=12'}
 
   strip-final-newline@2.0.0:
     resolution: {integrity: sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==}
@@ -1371,6 +1555,10 @@ packages:
     resolution: {integrity: sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==}
     hasBin: true
 
+  to-rotated@1.0.0:
+    resolution: {integrity: sha512-KsEID8AfgUy+pxVRLsWp0VzCa69wxzUDZnzGbyIST/bcgcrMvTYoFBX/QORH4YApoD89EDuUovx4BTdpOn319Q==}
+    engines: {node: '>=18'}
+
   tough-cookie@5.1.2:
     resolution: {integrity: sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==}
     engines: {node: '>=16'}
@@ -1387,6 +1575,10 @@ packages:
   type-fest@0.21.3:
     resolution: {integrity: sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==}
     engines: {node: '>=10'}
+
+  type-fest@4.41.0:
+    resolution: {integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==}
+    engines: {node: '>=16'}
 
   typescript@5.9.2:
     resolution: {integrity: sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==}
@@ -1514,9 +1706,17 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
+  widest-line@5.0.0:
+    resolution: {integrity: sha512-c9bZp7b5YtRj2wOe6dlj32MK+Bx/M/d+9VB2SHM1OtsUHR0aV0tdP6DWh/iMt0kWi1t5g1Iudu6hQRNd1A4PVA==}
+    engines: {node: '>=18'}
+
   wrap-ansi@6.2.0:
     resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
     engines: {node: '>=8'}
+
+  wrap-ansi@9.0.0:
+    resolution: {integrity: sha512-G8ura3S+3Z2G+mkgNRq8dqaFZAuxfsxpBB8OCTGRTCtp+l/v9nbFNmCUP1BZMts3G1142MsZfn6eeUKrr4PD1Q==}
+    engines: {node: '>=18'}
 
   ws@8.18.3:
     resolution: {integrity: sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==}
@@ -1541,7 +1741,15 @@ packages:
     resolution: {integrity: sha512-cYVsTjKl8b+FrnidjibDWskAv7UKOfcwaVZdp/it9n1s9fU3IkgDbhdIRKCW4JDsAlECJY0ytoVPT3sK6kideA==}
     engines: {node: '>=18'}
 
+  yoga-layout@3.2.1:
+    resolution: {integrity: sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==}
+
 snapshots:
+
+  '@alcalzone/ansi-tokenize@0.2.0':
+    dependencies:
+      ansi-styles: 6.2.1
+      is-fullwidth-code-point: 5.0.0
 
   '@asamuzakjp/css-color@3.2.0':
     dependencies:
@@ -2048,6 +2256,14 @@ snapshots:
     dependencies:
       undici-types: 7.10.0
 
+  '@types/react-dom@19.1.7(@types/react@19.1.10)':
+    dependencies:
+      '@types/react': 19.1.10
+
+  '@types/react@19.1.10':
+    dependencies:
+      csstype: 3.1.3
+
   '@types/tough-cookie@4.0.5': {}
 
   '@types/wrap-ansi@3.0.0': {}
@@ -2111,13 +2327,23 @@ snapshots:
     dependencies:
       type-fest: 0.21.3
 
+  ansi-escapes@7.0.0:
+    dependencies:
+      environment: 1.1.0
+
   ansi-regex@5.0.1: {}
+
+  ansi-regex@6.2.0: {}
 
   ansi-styles@4.3.0:
     dependencies:
       color-convert: 2.0.1
 
+  ansi-styles@6.2.1: {}
+
   assertion-error@2.0.1: {}
+
+  auto-bind@5.0.1: {}
 
   buffer-from@1.1.2: {}
 
@@ -2136,13 +2362,30 @@ snapshots:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
 
+  chalk@5.6.0: {}
+
   chardet@2.1.0: {}
 
   check-error@2.1.1: {}
 
+  cli-boxes@3.0.0: {}
+
+  cli-cursor@4.0.0:
+    dependencies:
+      restore-cursor: 4.0.0
+
   cli-spinners@2.9.2: {}
 
+  cli-truncate@4.0.0:
+    dependencies:
+      slice-ansi: 5.0.0
+      string-width: 7.2.0
+
   cli-width@4.1.0: {}
+
+  code-excerpt@4.0.0:
+    dependencies:
+      convert-to-spaces: 2.0.1
 
   color-convert@2.0.1:
     dependencies:
@@ -2154,6 +2397,8 @@ snapshots:
 
   commander@14.0.0: {}
 
+  convert-to-spaces@2.0.1: {}
+
   cross-spawn@7.0.6:
     dependencies:
       path-key: 3.1.1
@@ -2164,6 +2409,8 @@ snapshots:
     dependencies:
       '@asamuzakjp/css-color': 3.2.0
       rrweb-cssom: 0.8.0
+
+  csstype@3.1.3: {}
 
   data-uri-to-buffer@4.0.1: {}
 
@@ -2204,11 +2451,17 @@ snapshots:
       '@noble/curves': 1.9.7
       '@noble/hashes': 1.8.0
 
+  emoji-regex@10.4.0: {}
+
   emoji-regex@8.0.0: {}
 
   entities@6.0.1: {}
 
+  environment@1.1.0: {}
+
   es-module-lexer@1.7.0: {}
+
+  es-toolkit@1.39.10: {}
 
   esbuild-register@3.6.0(esbuild@0.25.9):
     dependencies:
@@ -2273,6 +2526,8 @@ snapshots:
 
   escape-string-regexp@1.0.5: {}
 
+  escape-string-regexp@2.0.0: {}
+
   escape-string-regexp@5.0.0: {}
 
   estree-walker@3.0.3:
@@ -2315,12 +2570,18 @@ snapshots:
       escape-string-regexp: 5.0.0
       is-unicode-supported: 1.3.0
 
+  figures@6.1.0:
+    dependencies:
+      is-unicode-supported: 2.1.0
+
   formdata-polyfill@4.0.10:
     dependencies:
       fetch-blob: 3.2.0
 
   fsevents@2.3.3:
     optional: true
+
+  get-east-asian-width@1.3.0: {}
 
   get-stream@6.0.1: {}
 
@@ -2356,6 +2617,55 @@ snapshots:
 
   ignore@5.3.2: {}
 
+  indent-string@5.0.0: {}
+
+  ink-select-input@6.2.0(ink@6.2.2(@types/react@19.1.10)(react@19.1.1))(react@19.1.1):
+    dependencies:
+      figures: 6.1.0
+      ink: 6.2.2(@types/react@19.1.10)(react@19.1.1)
+      react: 19.1.1
+      to-rotated: 1.0.0
+
+  ink-text-input@6.0.0(ink@6.2.2(@types/react@19.1.10)(react@19.1.1))(react@19.1.1):
+    dependencies:
+      chalk: 5.6.0
+      ink: 6.2.2(@types/react@19.1.10)(react@19.1.1)
+      react: 19.1.1
+      type-fest: 4.41.0
+
+  ink@6.2.2(@types/react@19.1.10)(react@19.1.1):
+    dependencies:
+      '@alcalzone/ansi-tokenize': 0.2.0
+      ansi-escapes: 7.0.0
+      ansi-styles: 6.2.1
+      auto-bind: 5.0.1
+      chalk: 5.6.0
+      cli-boxes: 3.0.0
+      cli-cursor: 4.0.0
+      cli-truncate: 4.0.0
+      code-excerpt: 4.0.0
+      es-toolkit: 1.39.10
+      indent-string: 5.0.0
+      is-in-ci: 2.0.0
+      patch-console: 2.0.0
+      react: 19.1.1
+      react-reconciler: 0.32.0(react@19.1.1)
+      scheduler: 0.26.0
+      signal-exit: 3.0.7
+      slice-ansi: 7.1.0
+      stack-utils: 2.0.6
+      string-width: 7.2.0
+      type-fest: 4.41.0
+      widest-line: 5.0.0
+      wrap-ansi: 9.0.0
+      ws: 8.18.3
+      yoga-layout: 3.2.1
+    optionalDependencies:
+      '@types/react': 19.1.10
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   inquirer-autocomplete-standalone@0.8.1:
     dependencies:
       '@inquirer/core': 3.1.2
@@ -2365,11 +2675,21 @@ snapshots:
 
   is-fullwidth-code-point@3.0.0: {}
 
+  is-fullwidth-code-point@4.0.0: {}
+
+  is-fullwidth-code-point@5.0.0:
+    dependencies:
+      get-east-asian-width: 1.3.0
+
+  is-in-ci@2.0.0: {}
+
   is-potential-custom-element-name@1.0.1: {}
 
   is-stream@2.0.1: {}
 
   is-unicode-supported@1.3.0: {}
+
+  is-unicode-supported@2.1.0: {}
 
   isexe@2.0.0: {}
 
@@ -2473,6 +2793,8 @@ snapshots:
     dependencies:
       entities: 6.0.1
 
+  patch-console@2.0.0: {}
+
   path-key@3.1.1: {}
 
   pathe@2.0.3: {}
@@ -2495,9 +2817,21 @@ snapshots:
 
   punycode@2.3.1: {}
 
+  react-reconciler@0.32.0(react@19.1.1):
+    dependencies:
+      react: 19.1.1
+      scheduler: 0.26.0
+
+  react@19.1.1: {}
+
   require-from-string@2.0.2: {}
 
   resolve-pkg-maps@1.0.0: {}
+
+  restore-cursor@4.0.0:
+    dependencies:
+      onetime: 5.1.2
+      signal-exit: 3.0.7
 
   rollup@4.46.4:
     dependencies:
@@ -2535,6 +2869,8 @@ snapshots:
     dependencies:
       xmlchars: 2.2.0
 
+  scheduler@0.26.0: {}
+
   shebang-command@2.0.0:
     dependencies:
       shebang-regex: 3.0.0
@@ -2547,6 +2883,16 @@ snapshots:
 
   signal-exit@4.1.0: {}
 
+  slice-ansi@5.0.0:
+    dependencies:
+      ansi-styles: 6.2.1
+      is-fullwidth-code-point: 4.0.0
+
+  slice-ansi@7.1.0:
+    dependencies:
+      ansi-styles: 6.2.1
+      is-fullwidth-code-point: 5.0.0
+
   source-map-js@1.2.1: {}
 
   source-map-support@0.5.21:
@@ -2555,6 +2901,10 @@ snapshots:
       source-map: 0.6.1
 
   source-map@0.6.1: {}
+
+  stack-utils@2.0.6:
+    dependencies:
+      escape-string-regexp: 2.0.0
 
   stackback@0.0.2: {}
 
@@ -2566,9 +2916,19 @@ snapshots:
       is-fullwidth-code-point: 3.0.0
       strip-ansi: 6.0.1
 
+  string-width@7.2.0:
+    dependencies:
+      emoji-regex: 10.4.0
+      get-east-asian-width: 1.3.0
+      strip-ansi: 7.1.0
+
   strip-ansi@6.0.1:
     dependencies:
       ansi-regex: 5.0.1
+
+  strip-ansi@7.1.0:
+    dependencies:
+      ansi-regex: 6.2.0
 
   strip-final-newline@2.0.0: {}
 
@@ -2603,6 +2963,8 @@ snapshots:
     dependencies:
       tldts-core: 6.1.86
 
+  to-rotated@1.0.0: {}
+
   tough-cookie@5.1.2:
     dependencies:
       tldts: 6.1.86
@@ -2619,6 +2981,8 @@ snapshots:
       fsevents: 2.3.3
 
   type-fest@0.21.3: {}
+
+  type-fest@4.41.0: {}
 
   typescript@5.9.2: {}
 
@@ -2736,11 +3100,21 @@ snapshots:
       siginfo: 2.0.0
       stackback: 0.0.2
 
+  widest-line@5.0.0:
+    dependencies:
+      string-width: 7.2.0
+
   wrap-ansi@6.2.0:
     dependencies:
       ansi-styles: 4.3.0
       string-width: 4.2.3
       strip-ansi: 6.0.1
+
+  wrap-ansi@9.0.0:
+    dependencies:
+      ansi-styles: 6.2.1
+      string-width: 7.2.0
+      strip-ansi: 7.1.0
 
   ws@8.18.3: {}
 
@@ -2749,3 +3123,5 @@ snapshots:
   xmlchars@2.2.0: {}
 
   yoctocolors-cjs@2.1.2: {}
+
+  yoga-layout@3.2.1: {}

--- a/src/external/tui/app.tsx
+++ b/src/external/tui/app.tsx
@@ -1,0 +1,543 @@
+import React, { useState, useEffect } from 'react';
+import { Box, Text, useApp } from 'ink';
+import SelectInput from 'ink-select-input';
+import TextInput from 'ink-text-input';
+import type { NodeType } from '../../domain/node.js';
+import type { CreateNodeUseCase } from '../../application/use-cases/create-node.js';
+import type { LinkNodesUseCase } from '../../application/use-cases/link-nodes.js';
+import type { PublishSiteUseCase } from '../../application/use-cases/publish-site.js';
+import type { SearchNodesUseCase } from '../../application/use-cases/search-nodes.js';
+import type { GetNodeUseCase } from '../../application/use-cases/get-node.js';
+import type { GenerateFlashcardsUseCase } from '../../application/use-cases/generate-flashcards.js';
+import type { Flashcard } from '../../application/ports/flashcard-generator.js';
+
+type Screen = 'menu' | 'create' | 'search' | 'flashcards' | 'publish' | 'exit';
+
+export type AppProps = {
+  createNodeUseCase: CreateNodeUseCase;
+  linkNodesUseCase: LinkNodesUseCase;
+  searchNodesUseCase: SearchNodesUseCase;
+  getNodeUseCase: GetNodeUseCase;
+  generateFlashcardsUseCase: GenerateFlashcardsUseCase;
+  publishSiteUseCase: PublishSiteUseCase;
+};
+
+const Menu: React.FC<{ onSelect: (s: Screen) => void }> = ({ onSelect }) => {
+  const items = [
+    { label: 'Create Node', value: 'create' },
+    { label: 'Search Nodes', value: 'search' },
+    { label: 'Generate Flashcards', value: 'flashcards' },
+    { label: 'Publish Site', value: 'publish' },
+    { label: 'Exit', value: 'exit' },
+  ];
+  return <SelectInput items={items} onSelect={(i) => onSelect(i.value as Screen)} />;
+};
+
+export const App: React.FC<AppProps> = (props) => {
+  const [screen, setScreen] = useState<Screen>('menu');
+  const { exit } = useApp();
+  useEffect(() => {
+    if (screen === 'exit') exit();
+  }, [screen, exit]);
+
+  switch (screen) {
+    case 'menu':
+      return <Menu onSelect={setScreen} />;
+    case 'create':
+      return <CreateNode {...props} onDone={() => setScreen('menu')} />;
+    case 'search':
+      return <SearchNodes {...props} onDone={() => setScreen('menu')} />;
+    case 'flashcards':
+      return <GenerateFlashcards {...props} onDone={() => setScreen('menu')} />;
+    case 'publish':
+      return <PublishSite {...props} onDone={() => setScreen('menu')} />;
+    default:
+      return <Text>Unknown screen</Text>;
+  }
+};
+
+// ---------- Create Node ----------
+
+type CreateNodeProps = AppProps & { onDone: () => void };
+
+const CreateNode: React.FC<CreateNodeProps> = ({
+  createNodeUseCase,
+  linkNodesUseCase,
+  onDone,
+}) => {
+  type Step =
+    | 'type'
+    | 'title'
+    | 'content'
+    | 'url'
+    | 'tag'
+    | 'flashcardFront'
+    | 'flashcardBack'
+    | 'isPublic'
+    | 'link'
+    | 'done';
+  const [step, setStep] = useState<Step>('type');
+  const [nodeType, setNodeType] = useState<NodeType>('note');
+  const [title, setTitle] = useState<string | undefined>(undefined);
+  const [data, setData] = useState<any>({});
+  const [isPublic, setIsPublic] = useState(false);
+  const [status, setStatus] = useState<string>('');
+  const [newId, setNewId] = useState<string | null>(null);
+  const [linkIds, setLinkIds] = useState('');
+
+  useEffect(() => {
+    const run = async () => {
+      if (step === 'done') {
+        onDone();
+      }
+      if (step === 'link' && newId) {
+        const ids = linkIds
+          .split(',')
+          .map((s) => s.trim())
+          .filter(Boolean);
+        for (const id of ids) {
+          await linkNodesUseCase.execute({ sourceId: newId, targetId: id });
+        }
+        setStatus(`Linked ${ids.length} nodes.`);
+        setStep('done');
+      }
+      if (step === 'isPublic') {
+        const res = await createNodeUseCase.execute({
+          type: nodeType,
+          title,
+          data,
+          isPublic,
+        });
+        if (res.ok) {
+          setStatus(`Created node ${res.result.id}`);
+          setNewId(res.result.id);
+          setStep('link');
+        } else {
+          setStatus(`Error: ${res.error}`);
+          setStep('done');
+        }
+      }
+    };
+    run();
+  }, [step, createNodeUseCase, linkNodesUseCase, nodeType, title, data, isPublic, linkIds, newId, onDone]);
+
+  if (step === 'type') {
+    return (
+      <Box flexDirection="column">
+        <Text>Select node type:</Text>
+        <SelectInput
+          items={[
+            { label: 'Note', value: 'note' },
+            { label: 'Link', value: 'link' },
+            { label: 'Tag', value: 'tag' },
+            { label: 'Flashcard', value: 'flashcard' },
+          ]}
+          onSelect={(i) => {
+            setNodeType(i.value as NodeType);
+            switch (i.value) {
+              case 'note':
+                setStep('title');
+                break;
+              case 'link':
+                setStep('url');
+                break;
+              case 'tag':
+                setStep('tag');
+                break;
+              case 'flashcard':
+                setStep('flashcardFront');
+                break;
+            }
+          }}
+        />
+      </Box>
+    );
+  }
+  if (step === 'title') {
+    return (
+      <Box flexDirection="column">
+        <Text>Enter note title:</Text>
+        <TextInput
+          value={title || ''}
+          onChange={(v) => setTitle(v)}
+          onSubmit={(v) => {
+            setTitle(v);
+            setStep('content');
+          }}
+        />
+      </Box>
+    );
+  }
+  if (step === 'content') {
+    return (
+      <Box flexDirection="column">
+        <Text>Enter note content:</Text>
+        <TextInput
+          value={data.content || ''}
+          onChange={(v) => setData({ ...data, content: v })}
+          onSubmit={(v) => {
+            setData({ ...data, content: v });
+            setStep('isPublic');
+          }}
+        />
+      </Box>
+    );
+  }
+  if (step === 'url') {
+    return (
+      <Box flexDirection="column">
+        <Text>Enter URL:</Text>
+        <TextInput
+          value={data.url || ''}
+          onChange={(v) => setData({ ...data, url: v })}
+          onSubmit={() => setStep('title')}
+        />
+      </Box>
+    );
+  }
+  if (step === 'tag') {
+    return (
+      <Box flexDirection="column">
+        <Text>Enter tag name:</Text>
+        <TextInput
+          value={data.name || ''}
+          onChange={(v) => setData({ name: v })}
+          onSubmit={(v) => {
+            setData({ name: v });
+            setStep('isPublic');
+          }}
+        />
+      </Box>
+    );
+  }
+  if (step === 'flashcardFront') {
+    return (
+      <Box flexDirection="column">
+        <Text>Enter flashcard front:</Text>
+        <TextInput
+          value={data.front || ''}
+          onChange={(v) => setData({ ...data, front: v })}
+          onSubmit={(v) => {
+            setData({ ...data, front: v });
+            setStep('flashcardBack');
+          }}
+        />
+      </Box>
+    );
+  }
+  if (step === 'flashcardBack') {
+    return (
+      <Box flexDirection="column">
+        <Text>Enter flashcard back:</Text>
+        <TextInput
+          value={data.back || ''}
+          onChange={(v) => setData({ ...data, back: v })}
+          onSubmit={(v) => {
+            setData({ ...data, back: v });
+            setStep('isPublic');
+          }}
+        />
+      </Box>
+    );
+  }
+  if (step === 'isPublic') {
+    return (
+      <Box flexDirection="column">
+        <Text>Make this node public?</Text>
+        <SelectInput
+          items={[
+            { label: 'Yes', value: 'yes' },
+            { label: 'No', value: 'no' },
+          ]}
+          onSelect={(i) => {
+            setIsPublic(i.value === 'yes');
+            setStep('isPublic'); // trigger useEffect to create
+          }}
+        />
+      </Box>
+    );
+  }
+  if (step === 'link') {
+    return (
+      <Box flexDirection="column">
+        <Text>{status}</Text>
+        <Text>Enter node IDs to link (comma separated) or press enter to skip:</Text>
+        <TextInput
+          value={linkIds}
+          onChange={setLinkIds}
+          onSubmit={(v) => {
+            setLinkIds(v);
+            setStep('link');
+          }}
+        />
+      </Box>
+    );
+  }
+  if (step === 'done') {
+    return (
+      <Box flexDirection="column">
+        <Text>{status}</Text>
+        <Text>Press enter to return to menu.</Text>
+        <TextInput value="" onSubmit={() => onDone()} />
+      </Box>
+    );
+  }
+  return <Text>{status}</Text>;
+};
+
+// ---------- Search Nodes ----------
+
+type SearchProps = AppProps & { onDone: () => void };
+
+const SearchNodes: React.FC<SearchProps> = ({
+  searchNodesUseCase,
+  getNodeUseCase,
+  onDone,
+}) => {
+  const [query, setQuery] = useState('');
+  const [results, setResults] = useState<
+    Array<{ label: string; value: string }>
+  >([]);
+  const [display, setDisplay] = useState<any | null>(null);
+
+  useEffect(() => {
+    const run = async () => {
+      if (query && results.length === 0 && display === null) {
+        const res = await searchNodesUseCase.execute({ query });
+        if (res.ok) {
+          setResults(
+            res.result.map(({ node, score }) => ({
+              label: `[${node.type.toUpperCase()}] ${node.title} (${score.toFixed(
+                2
+              )})`,
+              value: node.id,
+            }))
+          );
+        }
+      }
+    };
+    run();
+  }, [query, results, display, searchNodesUseCase]);
+
+  if (display) {
+    return (
+      <Box flexDirection="column">
+        <Text>{JSON.stringify(display, null, 2)}</Text>
+        <Text>Press enter to return.</Text>
+        <TextInput value="" onSubmit={() => onDone()} />
+      </Box>
+    );
+  }
+
+  if (results.length > 0) {
+    return (
+      <Box flexDirection="column">
+        <SelectInput
+          items={results}
+          onSelect={async (item) => {
+            const res = await getNodeUseCase.execute({ id: item.value });
+            if (res.ok) {
+              setDisplay(res.result);
+            } else {
+              setDisplay({ error: res.error });
+            }
+          }}
+        />
+      </Box>
+    );
+  }
+
+  return (
+    <Box flexDirection="column">
+      <Text>Search query:</Text>
+      <TextInput
+        value={query}
+        onChange={setQuery}
+        onSubmit={setQuery}
+      />
+    </Box>
+  );
+};
+
+// ---------- Generate Flashcards ----------
+
+type FlashcardProps = AppProps & { onDone: () => void };
+
+const GenerateFlashcards: React.FC<FlashcardProps> = ({
+  searchNodesUseCase,
+  getNodeUseCase,
+  generateFlashcardsUseCase,
+  createNodeUseCase,
+  linkNodesUseCase,
+  onDone,
+}) => {
+  type Step = 'query' | 'select' | 'review' | 'public' | 'saving' | 'done';
+  const [step, setStep] = useState<Step>('query');
+  const [query, setQuery] = useState('');
+  const [results, setResults] = useState<
+    Array<{ label: string; value: string }>
+  >([]);
+  const [nodeId, setNodeId] = useState<string>('');
+  const [cards, setCards] = useState<Array<Flashcard>>([]);
+  const [kept, setKept] = useState<Array<Flashcard>>([]);
+  const [index, setIndex] = useState(0);
+  const [makePublic, setMakePublic] = useState(false);
+  const [status, setStatus] = useState('');
+
+  useEffect(() => {
+    const run = async () => {
+      if (step === 'select' && results.length === 0) {
+        const res = await searchNodesUseCase.execute({ query });
+        if (res.ok) {
+          setResults(
+            res.result.map(({ node, score }) => ({
+              label: `[${node.type.toUpperCase()}] ${node.title} (${score.toFixed(
+                2
+              )})`,
+              value: node.id,
+            }))
+          );
+        } else {
+          setStatus(res.error);
+          setStep('done');
+        }
+      }
+      if (step === 'review') {
+        const res = await generateFlashcardsUseCase.execute({ id: nodeId });
+        if (res.ok) {
+          setCards(res.result);
+        } else {
+          setStatus(res.error);
+          setStep('done');
+        }
+      }
+      if (step === 'saving') {
+        for (const card of kept) {
+          const save = await createNodeUseCase.execute({
+            type: 'flashcard',
+            data: { front: card.front, back: card.back },
+            isPublic: makePublic,
+          });
+          if (save.ok) {
+            await linkNodesUseCase.execute({
+              sourceId: nodeId,
+              targetId: save.result.id,
+            });
+          }
+        }
+        setStatus(`Saved ${kept.length} cards.`);
+        setStep('done');
+      }
+    };
+    run();
+  }, [step, query, results, nodeId, kept, makePublic, searchNodesUseCase, generateFlashcardsUseCase, createNodeUseCase, linkNodesUseCase]);
+
+  if (step === 'query') {
+    return (
+      <Box flexDirection="column">
+        <Text>Search for source node:</Text>
+        <TextInput value={query} onChange={setQuery} onSubmit={() => setStep('select')} />
+      </Box>
+    );
+  }
+  if (step === 'select') {
+    return (
+      <SelectInput
+        items={results}
+        onSelect={(item) => {
+          setNodeId(item.value);
+          setStep('review');
+        }}
+      />
+    );
+  }
+  if (step === 'review') {
+    if (cards.length === 0) {
+      return <Text>Generating flashcards...</Text>;
+    }
+    const card = cards[index];
+    if (!card) {
+      setStep('public');
+      return null;
+    }
+    return (
+      <Box flexDirection="column">
+        <Text>Card {index + 1} of {cards.length}</Text>
+        <Text>Front: {card.front}</Text>
+        <Text>Back: {card.back}</Text>
+        <SelectInput
+          items={[
+            { label: 'Keep', value: 'keep' },
+            { label: 'Discard', value: 'discard' },
+          ]}
+          onSelect={(item) => {
+            if (item.value === 'keep') {
+              setKept([...kept, card]);
+            }
+            setIndex(index + 1);
+          }}
+        />
+      </Box>
+    );
+  }
+  if (step === 'public') {
+    return (
+      <Box flexDirection="column">
+        <Text>Make kept cards public?</Text>
+        <SelectInput
+          items={[
+            { label: 'Yes', value: 'yes' },
+            { label: 'No', value: 'no' },
+          ]}
+          onSelect={(i) => {
+            setMakePublic(i.value === 'yes');
+            setStep('saving');
+          }}
+        />
+      </Box>
+    );
+  }
+  if (step === 'saving') {
+    return <Text>Saving cards...</Text>;
+  }
+  if (step === 'done') {
+    return (
+      <Box flexDirection="column">
+        <Text>{status}</Text>
+        <Text>Press enter to return.</Text>
+        <TextInput value="" onSubmit={() => onDone()} />
+      </Box>
+    );
+  }
+  return null;
+};
+
+// ---------- Publish Site ----------
+
+type PublishProps = AppProps & { onDone: () => void };
+
+const PublishSite: React.FC<PublishProps> = ({ publishSiteUseCase, onDone }) => {
+  const [status, setStatus] = useState('Publishing...');
+  useEffect(() => {
+    const run = async () => {
+      const res = await publishSiteUseCase.execute();
+      if (res.ok) {
+        setStatus(
+          `Published ${res.result.filesGenerated} files to ${res.result.outputDir}`
+        );
+      } else {
+        setStatus(`Error: ${res.error}`);
+      }
+    };
+    run();
+  }, [publishSiteUseCase]);
+
+  return (
+    <Box flexDirection="column">
+      <Text>{status}</Text>
+      <Text>Press enter to return.</Text>
+      <TextInput value="" onSubmit={() => onDone()} />
+    </Box>
+  );
+};
+

--- a/src/tui.tsx
+++ b/src/tui.tsx
@@ -1,0 +1,100 @@
+import React from 'react';
+import { render } from 'ink';
+import { App } from './external/tui/app.js';
+import { AjvValidator } from './external/validation/ajv-validator.js';
+import { NodeFactory } from './domain/node-factory.js';
+import { createDatabaseClient } from './external/database/client.js';
+import { SqlNodeRepository } from './external/repositories/sql-node-repository.js';
+import { HTMLGenerator } from './external/publishers/html-generator.js';
+import { NodeMapper } from './adapters/node-mapper.js';
+import { HTTPCrawler } from './external/crawlers/http-crawler.js';
+import { OllamaFlashcardGenerator } from './external/ai-services/ollama-flashcard-generator.js';
+import { CreateNodeUseCase } from './application/use-cases/create-node.js';
+import { GetNodeUseCase } from './application/use-cases/get-node.js';
+import { PublishSiteUseCase } from './application/use-cases/publish-site.js';
+import { LinkNodesUseCase } from './application/use-cases/link-nodes.js';
+import { SearchNodesUseCase } from './application/use-cases/search-nodes.js';
+import { GenerateFlashcardsUseCase } from './application/use-cases/generate-flashcards.js';
+import type { JSONSchema } from './domain/ports/validator.js';
+
+function initSchemas(nodeFactory: NodeFactory) {
+  const noteSchema = {
+    type: 'object',
+    properties: { content: { type: 'string' } },
+    required: ['content'],
+    additionalProperties: false,
+  } satisfies JSONSchema;
+
+  const linkSchema = {
+    type: 'object',
+    properties: {
+      url: { type: 'string' },
+      text: { type: 'string' },
+      html: { type: 'string' },
+    },
+    required: ['url', 'text', 'html'],
+    additionalProperties: false,
+  } satisfies JSONSchema;
+
+  const tagSchema = {
+    type: 'object',
+    properties: { name: { type: 'string' } },
+    required: ['name'],
+    additionalProperties: false,
+  } satisfies JSONSchema;
+
+  const flashcardSchema = {
+    type: 'object',
+    properties: { front: { type: 'string' }, back: { type: 'string' } },
+    required: ['front', 'back'],
+    additionalProperties: false,
+  } satisfies JSONSchema;
+
+  nodeFactory.registerSchema('note', noteSchema);
+  nodeFactory.registerSchema('link', linkSchema);
+  nodeFactory.registerSchema('tag', tagSchema);
+  nodeFactory.registerSchema('flashcard', flashcardSchema);
+}
+
+function run() {
+  const validator = new AjvValidator();
+  const nodeFactory = new NodeFactory(validator);
+  initSchemas(nodeFactory);
+  const nodeMapper = new NodeMapper(nodeFactory);
+  const db = createDatabaseClient(process.env.DATABASE_URL || 'file:local.db');
+  const nodeRepository = new SqlNodeRepository(db, nodeMapper);
+  const htmlGenerator = new HTMLGenerator();
+  const crawler = new HTTPCrawler();
+  const flashcardGenerator = new OllamaFlashcardGenerator();
+
+  const createNode = new CreateNodeUseCase(nodeFactory, nodeRepository, crawler);
+  const linkNodes = new LinkNodesUseCase(nodeRepository);
+  const searchNodes = new SearchNodesUseCase(nodeRepository);
+  const getNode = new GetNodeUseCase(nodeRepository);
+  const generateFlashcards = new GenerateFlashcardsUseCase(
+    nodeRepository,
+    flashcardGenerator
+  );
+  const publishSite = new PublishSiteUseCase(
+    nodeRepository,
+    htmlGenerator,
+    './public'
+  );
+
+  render(
+    <App
+      createNodeUseCase={createNode}
+      linkNodesUseCase={linkNodes}
+      searchNodesUseCase={searchNodes}
+      getNodeUseCase={getNode}
+      generateFlashcardsUseCase={generateFlashcards}
+      publishSiteUseCase={publishSite}
+    />
+  );
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  run();
+}
+
+export { run };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,6 +26,7 @@
     "noFallthroughCasesInSwitch": true,
     "useUnknownInCatchVariables": true,
     "verbatimModuleSyntax": true /* Avoid TS inserting synthetic exports; preserves ESM shape. */,
+    "jsx": "react-jsx",
 
     /* Interop & Module Hygiene */
     "esModuleInterop": true /* Smooth default import of CJS deps. */,
@@ -37,6 +38,6 @@
     "types": ["node", "vitest"] /* Include Node + Vitest globals for tests. */,
     "incremental": false /* Speeds up subsequent builds (creates .tsbuildinfo). */
   },
-  "include": ["src/**/*.ts"],
+  "include": ["src/**/*.ts", "src/**/*.tsx"],
   "exclude": ["dist", "node_modules"]
 }


### PR DESCRIPTION
## Summary
- add React/Ink-based TUI to replace CLI interactions
- support create/search/flashcard/publish flows via new TUI app
- wire up new tui entrypoint and dependencies

## Testing
- `pnpm test --run`


------
https://chatgpt.com/codex/tasks/task_e_68a863a1d53c832aa56e124134a4fdb4