### PR TITLE
refactor: remove title param from tag and flashcard creation

### DIFF
--- a/src/application/use-cases/create-node.ts
+++ b/src/application/use-cases/create-node.ts
@@ -9,7 +9,6 @@ import type { Crawler } from '../ports/crawler.js';
 type CreateNodeInput =
   | {
       type: 'flashcard';
-      title?: string | undefined;
       isPublic: boolean;
       data: { front: string; back: string };
     }

--- a/src/domain/flashcard-node.ts
+++ b/src/domain/flashcard-node.ts
@@ -31,7 +31,6 @@ class FlashcardNode extends BaseNode {
 
   static create(input: {
     isPublic: boolean;
-    title?: string;
     data: FlashcardNodeData;
   }): FlashcardNode {
     const id = randomUUID();

--- a/src/domain/tag-node.ts
+++ b/src/domain/tag-node.ts
@@ -30,7 +30,6 @@ class TagNode extends BaseNode {
 
   static create(input: {
     isPublic: boolean;
-    title?: string;
     data: TagNodeData;
   }): TagNode {
     const id = randomUUID();

--- a/src/external/cli/cli.ts
+++ b/src/external/cli/cli.ts
@@ -79,7 +79,7 @@ export class CLI {
       });
 
       // Step 2: Collect data based on node type
-      const { title, data } = await this.collectNodeInput(nodeType);
+      const input = await this.collectNodeInput(nodeType);
 
       // Step 3: Ask if node should be public
       const isPublic = await confirm({
@@ -90,8 +90,7 @@ export class CLI {
       // Step 4: Create the node
       const result = await this.createNodeUseCase.execute({
         type: nodeType,
-        title,
-        data,
+        ...input,
         isPublic,
       });
 
@@ -399,7 +398,7 @@ export class CLI {
 
   private async collectNodeInput(
     nodeType: NodeType
-  ): Promise<{ title: string | undefined; data: Record<string, unknown> }> {
+  ): Promise<{ title?: string; data: Record<string, unknown> }> {
     switch (nodeType) {
       case 'note': {
         const title = await input({
@@ -439,7 +438,7 @@ export class CLI {
               value.trim().length > 0 || 'Name is required',
           }),
         };
-        return { title: undefined, data };
+        return { data };
       }
 
       case 'flashcard': {
@@ -455,7 +454,7 @@ export class CLI {
               value.trim().length > 0 || 'Back text is required',
           }),
         };
-        return { title: undefined, data };
+        return { data };
       }
 
       default:


### PR DESCRIPTION
## Summary
- drop the unused `title` argument from `TagNode.create` and `FlashcardNode.create`
- simplify `CreateNodeUseCase` and CLI to construct tag/flashcard nodes without titles

## Testing
- `pnpm test` *(fails: SQLITE_ERROR: no such table: nodes)*

------
https://chatgpt.com/codex/tasks/task_e_68aada412a7c832a8e28a0a88f0d3656