### PR TITLE
refactor: centralize node type definition

### DIFF
--- a/src/domain/base-node.ts
+++ b/src/domain/base-node.ts
@@ -1,6 +1,8 @@
+import type { NodeType } from './node-types.js';
+
 abstract class BaseNode {
   readonly id: string;
-  abstract readonly type: 'note' | 'link' | 'tag' | 'flashcard';
+  abstract readonly type: NodeType;
   readonly version: number;
   readonly createdAt: Date;
   readonly updatedAt: Date;

--- a/src/domain/node-types.ts
+++ b/src/domain/node-types.ts
@@ -1,0 +1,6 @@
+const NODE_TYPES = ['note', 'link', 'tag', 'flashcard'] as const;
+
+type NodeType = (typeof NODE_TYPES)[number];
+
+export { NODE_TYPES };
+export type { NodeType };

--- a/src/domain/types.ts
+++ b/src/domain/types.ts
@@ -2,9 +2,9 @@ import { FlashcardNode } from './flashcard-node.js';
 import { LinkNode } from './link-node.js';
 import { NoteNode } from './note-node.js';
 import { TagNode } from './tag-node.js';
+import type { NodeType } from './node-types.js';
 
 type AnyNode = FlashcardNode | LinkNode | NoteNode | TagNode;
-type NodeType = AnyNode['type'];
 
 type EdgeType =
   | 'references'


### PR DESCRIPTION
## Summary
- import NodeType into BaseNode
- use NodeType for BaseNode type property to centralize declarations
- extract NodeType into its own module to break circular dependencies

## Testing
- `pnpm run typecheck` (fails: 'response.message.tool_calls' is possibly undefined and CLI type mismatch)
- `pnpm run test` (fails: no such table: nodes in publish-site tests)


------
https://chatgpt.com/codex/tasks/task_e_68aada43ef8c832ab3e37577cdf0e3a5