### PR TITLE
refactor: rename SqlNodeRepository to SqliteNodeRepository

### DIFF
--- a/src/application/use-cases/publish-site.test.ts
+++ b/src/application/use-cases/publish-site.test.ts
@@ -9,7 +9,7 @@ import { NoteNode } from '../../domain/note-node.js';
 import { LinkNode } from '../../domain/link-node.js';
 import { TagNode } from '../../domain/tag-node.js';
 import { FlashcardNode } from '../../domain/flashcard-node.js';
-import { SqlNodeRepository } from '../../external/repositories/sqlite-node-repository.js';
+import { SqliteNodeRepository } from '../../external/repositories/sqlite-node-repository.js';
 import { HTMLGenerator } from '../../external/publishers/html-generator.js';
 import { PublishSiteUseCase } from './publish-site.js';
 import {
@@ -18,7 +18,7 @@ import {
 } from '../../external/database/client.js';
 
 let db: DatabaseClient;
-let repository: SqlNodeRepository;
+let repository: SqliteNodeRepository;
 let outputDir: string;
 
 beforeEach(async () => {
@@ -26,7 +26,7 @@ beforeEach(async () => {
   await migrate(db, { migrationsFolder: './drizzle' });
 
   const mapper = new NodeMapper();
-  repository = new SqlNodeRepository(db, mapper);
+  repository = new SqliteNodeRepository(db, mapper);
 
   outputDir = await fs.mkdtemp(path.join(os.tmpdir(), 'publish-test-'));
 });

--- a/src/external/repositories/sqlite-node-repository.test.ts
+++ b/src/external/repositories/sqlite-node-repository.test.ts
@@ -7,7 +7,7 @@ import { sql } from 'drizzle-orm';
 import { migrate } from 'drizzle-orm/libsql/migrator';
 import { NodeMapper } from '../../adapters/node-mapper.js';
 import { NoteNode } from '../../domain/note-node.js';
-import { SqlNodeRepository } from './sqlite-node-repository.js';
+import { SqliteNodeRepository } from './sqlite-node-repository.js';
 import {
   createDatabaseClient,
   type DatabaseClient,
@@ -34,9 +34,9 @@ const nodes = [
   },
 ];
 
-describe('SQLNodeRepository', () => {
+describe('SqliteNodeRepository', () => {
   let db: DatabaseClient;
-  let repository: SqlNodeRepository;
+  let repository: SqliteNodeRepository;
   let dbFile: string;
 
   beforeEach(async () => {
@@ -46,7 +46,7 @@ describe('SQLNodeRepository', () => {
     await migrate(db, { migrationsFolder: './drizzle' });
 
     const mapper = new NodeMapper();
-    repository = new SqlNodeRepository(db, mapper);
+    repository = new SqliteNodeRepository(db, mapper);
   });
 
   afterEach(async () => {

--- a/src/external/repositories/sqlite-node-repository.ts
+++ b/src/external/repositories/sqlite-node-repository.ts
@@ -16,7 +16,7 @@ import type {
 } from '../../application/ports/node-repository.js';
 import type { AnyNode, EdgeType } from '../../domain/types.js';
 
-export class SqlNodeRepository implements NodeRepository {
+export class SqliteNodeRepository implements NodeRepository {
   constructor(
     private db: DatabaseClient,
     private mapper: NodeMapper

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,5 @@
 import { createDatabaseClient } from './external/database/client.js';
-import { SqlNodeRepository } from './external/repositories/sqlite-node-repository.js';
+import { SqliteNodeRepository } from './external/repositories/sqlite-node-repository.js';
 import { HTMLGenerator } from './external/publishers/html-generator.js';
 import { NodeMapper } from './adapters/node-mapper.js';
 import { HTTPCrawler } from './external/crawlers/http-crawler.js';
@@ -22,7 +22,7 @@ class Application {
     const db = createDatabaseClient(
       process.env.DATABASE_URL || 'file:local.db'
     );
-    const nodeRepository = new SqlNodeRepository(db, nodeMapper);
+    const nodeRepository = new SqliteNodeRepository(db, nodeMapper);
     const htmlGenerator = new HTMLGenerator();
     const crawler = new HTTPCrawler();
     const flashcardGenerator = new OllamaFlashcardGenerator();


### PR DESCRIPTION
## Summary
- rename SqlNodeRepository to SqliteNodeRepository
- update imports and references

## Testing
- `pnpm run test` *(fails: SQLITE_ERROR: no such table: nodes)*

------
https://chatgpt.com/codex/tasks/task_e_68aadac7afac832a80cc79b39bae6d91