### PR TITLE
docs: add jsdoc to domain nodes

### DIFF
--- a/src/domain/base-node.ts
+++ b/src/domain/base-node.ts
@@ -1,3 +1,6 @@
+/**
+ * Base class for all node types in the knowledge graph.
+ */
 abstract class BaseNode {
   readonly id: string;
   abstract readonly type: 'note' | 'link' | 'tag' | 'flashcard';
@@ -5,6 +8,12 @@ abstract class BaseNode {
   readonly createdAt: Date;
   readonly updatedAt: Date;
   readonly isPublic: boolean;
+
+  /**
+   * Gets the human readable title for the node.
+   *
+   * @returns Node title.
+   */
   abstract get title(): string;
 
   constructor(props: {

--- a/src/domain/flashcard-node.ts
+++ b/src/domain/flashcard-node.ts
@@ -15,6 +15,9 @@ interface FlashcardNodeProps {
   data: FlashcardNodeData;
 }
 
+/**
+ * Node representing a flashcard with front and back text.
+ */
 class FlashcardNode extends BaseNode {
   readonly type: 'flashcard';
   readonly data: FlashcardNodeData;
@@ -25,10 +28,21 @@ class FlashcardNode extends BaseNode {
     this.data = input.data;
   }
 
+  /**
+   * Gets the front text which acts as the flashcard's title.
+   *
+   * @returns Flashcard front text.
+   */
   get title() {
     return this.data.front;
   }
 
+  /**
+   * Creates a new flashcard node with generated id and timestamps.
+   *
+   * @param input Object containing visibility and flashcard data.
+   * @returns Newly created flashcard node.
+   */
   static create(input: {
     isPublic: boolean;
     title?: string;
@@ -46,6 +60,12 @@ class FlashcardNode extends BaseNode {
     });
   }
 
+  /**
+   * Recreates a flashcard node from persisted properties.
+   *
+   * @param input Complete flashcard node properties.
+   * @returns Hydrated flashcard node instance.
+   */
   static hydrate(input: FlashcardNodeProps): FlashcardNode {
     return new FlashcardNode(input);
   }

--- a/src/domain/link-node.ts
+++ b/src/domain/link-node.ts
@@ -20,6 +20,9 @@ interface LinkNodeProps {
   data: LinkNodeData;
 }
 
+/**
+ * Node representing a web link with optional crawled metadata.
+ */
 class LinkNode extends BaseNode {
   readonly type: 'link';
   private _title: string | undefined;
@@ -32,10 +35,21 @@ class LinkNode extends BaseNode {
     this.data = input.data;
   }
 
+  /**
+   * Gets the link's title or falls back to crawled data and URL.
+   *
+   * @returns Resolved link title.
+   */
   get title() {
     return this._title || this.data.crawled.title || this.data.url;
   }
 
+  /**
+   * Creates a new link node with generated id and timestamps.
+   *
+   * @param input Object containing visibility, optional title and link data.
+   * @returns Newly created link node.
+   */
   static create(input: {
     isPublic: boolean;
     title?: string | undefined;
@@ -54,6 +68,12 @@ class LinkNode extends BaseNode {
     });
   }
 
+  /**
+   * Recreates a link node from persisted properties.
+   *
+   * @param input Complete link node properties.
+   * @returns Hydrated link node instance.
+   */
   static hydrate(input: LinkNodeProps): LinkNode {
     return new LinkNode(input);
   }

--- a/src/domain/note-node.ts
+++ b/src/domain/note-node.ts
@@ -15,6 +15,9 @@ interface NoteNodeProps {
   data: NoteNodeData;
 }
 
+/**
+ * Node representing a textual note with a title and content body.
+ */
 class NoteNode extends BaseNode {
   readonly type: 'note';
   private _title: string;
@@ -27,14 +30,30 @@ class NoteNode extends BaseNode {
     this.data = input.data;
   }
 
+  /**
+   * Gets the note's title.
+   *
+   * @returns Note title.
+   */
   get title() {
     return this._title;
   }
 
+  /**
+   * Gets the note's content body.
+   *
+   * @returns Note content text.
+   */
   get content() {
     return this.data.content;
   }
 
+  /**
+   * Creates a new note node with generated id and timestamps.
+   *
+   * @param input Object containing visibility, title and note data.
+   * @returns Newly created note node.
+   */
   static create(input: {
     isPublic: boolean;
     title: string;
@@ -53,6 +72,12 @@ class NoteNode extends BaseNode {
     });
   }
 
+  /**
+   * Recreates a note node from persisted properties.
+   *
+   * @param input Complete note node properties.
+   * @returns Hydrated note node instance.
+   */
   static hydrate(input: NoteNodeProps): NoteNode {
     return new NoteNode(input);
   }

--- a/src/domain/tag-node.ts
+++ b/src/domain/tag-node.ts
@@ -14,6 +14,9 @@ interface TagNodeProps {
   data: TagNodeData;
 }
 
+/**
+ * Node representing a tag used for categorizing other nodes.
+ */
 class TagNode extends BaseNode {
   readonly type: 'tag';
   readonly data: TagNodeData;
@@ -24,10 +27,21 @@ class TagNode extends BaseNode {
     this.data = input.data;
   }
 
+  /**
+   * Gets the tag's display name.
+   *
+   * @returns Tag name.
+   */
   get title() {
     return this.data.name;
   }
 
+  /**
+   * Creates a new tag node with generated id and timestamps.
+   *
+   * @param input Object containing visibility and tag data.
+   * @returns Newly created tag node.
+   */
   static create(input: {
     isPublic: boolean;
     title?: string;
@@ -45,6 +59,12 @@ class TagNode extends BaseNode {
     });
   }
 
+  /**
+   * Recreates a tag node from persisted properties.
+   *
+   * @param input Complete tag node properties.
+   * @returns Hydrated tag node instance.
+   */
   static hydrate(input: TagNodeProps): TagNode {
     return new TagNode(input);
   }


### PR DESCRIPTION
## Summary
- document BaseNode and concrete node implementations with JSDoc
- describe getters and static factory/hydration methods

## Testing
- `pnpm test` *(fails: SQLITE_ERROR no such table: nodes)*

------
https://chatgpt.com/codex/tasks/task_e_68aadaa9321c832aacec5c1de8234b6e