### PR TITLE
feat: add search index service

### DIFF
--- a/drizzle/0001_add_fts_to_nodes.sql
+++ b/drizzle/0001_add_fts_to_nodes.sql
@@ -1,21 +1,9 @@
 -- Create a standalone FTS index (not using external content)
 CREATE VIRTUAL TABLE nodes_fts USING fts5(
   id UNINDEXED,
-  title, 
+  title,
+  searchable_content,
+  type,
   tokenize='porter unicode61 remove_diacritics 2',
   prefix='2 3'
-);--> statement-breakpoint
-
--- Keep the FTS index in sync with nodes table
-CREATE TRIGGER nodes_after_insert AFTER INSERT ON nodes BEGIN
-  INSERT INTO nodes_fts(id, title) VALUES (new.id, new.title);
-END;--> statement-breakpoint
-
-CREATE TRIGGER nodes_after_delete AFTER DELETE ON nodes BEGIN
-  DELETE FROM nodes_fts WHERE id = old.id;
-END;--> statement-breakpoint
-
-CREATE TRIGGER nodes_after_update AFTER UPDATE ON nodes BEGIN
-  DELETE FROM nodes_fts WHERE id = old.id;
-  INSERT INTO nodes_fts(id, title) VALUES (new.id, new.title);
-END;
+);

--- a/src/application/ports/search-index.ts
+++ b/src/application/ports/search-index.ts
@@ -1,0 +1,8 @@
+import type { AnyNode } from '../../domain/types.js';
+
+interface SearchIndex {
+  indexNode(node: AnyNode): Promise<void>;
+  removeNode(id: string): Promise<void>;
+}
+
+export type { SearchIndex };

--- a/src/application/use-cases/create-node.ts
+++ b/src/application/use-cases/create-node.ts
@@ -3,8 +3,9 @@ import { LinkNode } from '../../domain/link-node.js';
 import { NoteNode } from '../../domain/note-node.js';
 import { TagNode } from '../../domain/tag-node.js';
 import type { NodeRepository } from '../ports/node-repository.js';
-import type { AnyNode, NodeType } from '../../domain/types.js';
+import type { AnyNode } from '../../domain/types.js';
 import type { Crawler } from '../ports/crawler.js';
+import type { SearchIndex } from '../ports/search-index.js';
 
 type CreateNodeInput =
   | {
@@ -33,7 +34,8 @@ type CreateNodeInput =
 class CreateNodeUseCase {
   constructor(
     private readonly repository: NodeRepository,
-    private readonly crawler: Crawler
+    private readonly crawler: Crawler,
+    private readonly searchIndex: SearchIndex
   ) {}
 
   async execute(input: CreateNodeInput) {
@@ -77,6 +79,7 @@ class CreateNodeUseCase {
       }
 
       await this.repository.save(node);
+      await this.searchIndex.indexNode(node);
       return { ok: true as const, result: node };
     } catch (err) {
       return { ok: false as const, error: (err as Error).message };

--- a/src/domain/base-node.ts
+++ b/src/domain/base-node.ts
@@ -18,6 +18,13 @@ abstract class BaseNode {
    */
   abstract get title(): string;
 
+  /**
+   * Gets content that should be indexed for search.
+   *
+   * @returns Searchable text content.
+   */
+  abstract get searchableContent(): string;
+
   constructor(props: {
     id: string;
     version: number;

--- a/src/domain/flashcard-node.ts
+++ b/src/domain/flashcard-node.ts
@@ -37,6 +37,10 @@ class FlashcardNode extends BaseNode {
     return this.data.front;
   }
 
+  get searchableContent() {
+    return `${this.data.front} ${this.data.back}`;
+  }
+
   /**
    * Creates a new flashcard node with generated id and timestamps.
    *

--- a/src/domain/link-node.ts
+++ b/src/domain/link-node.ts
@@ -44,6 +44,16 @@ class LinkNode extends BaseNode {
     return this._title || this.data.crawled.title || this.data.url;
   }
 
+  get searchableContent() {
+    return [
+      this.data.url,
+      this.data.crawled.title,
+      this.data.crawled.text,
+    ]
+      .filter(Boolean)
+      .join(' ');
+  }
+
   /**
    * Creates a new link node with generated id and timestamps.
    *

--- a/src/domain/note-node.ts
+++ b/src/domain/note-node.ts
@@ -48,6 +48,10 @@ class NoteNode extends BaseNode {
     return this.data.content;
   }
 
+  get searchableContent() {
+    return this.data.content;
+  }
+
   /**
    * Creates a new note node with generated id and timestamps.
    *

--- a/src/domain/tag-node.ts
+++ b/src/domain/tag-node.ts
@@ -36,6 +36,10 @@ class TagNode extends BaseNode {
     return this.data.name;
   }
 
+  get searchableContent() {
+    return this.data.name;
+  }
+
   /**
    * Creates a new tag node with generated id and timestamps.
    *

--- a/src/external/repositories/sqlite-node-repository.test.ts
+++ b/src/external/repositories/sqlite-node-repository.test.ts
@@ -12,6 +12,7 @@ import {
   createDatabaseClient,
   type DatabaseClient,
 } from '../database/client.js';
+import { SqliteSearchIndex } from '../search-index/sqlite-search-index.js';
 
 const nodes = [
   {
@@ -38,6 +39,7 @@ describe('SqliteNodeRepository', () => {
   let db: DatabaseClient;
   let repository: SqliteNodeRepository;
   let dbFile: string;
+  let searchIndex: SqliteSearchIndex;
 
   beforeEach(async () => {
     // Use a temp file vs in memory to allow for transactions to work
@@ -47,6 +49,7 @@ describe('SqliteNodeRepository', () => {
 
     const mapper = new NodeMapper();
     repository = new SqliteNodeRepository(db, mapper);
+    searchIndex = new SqliteSearchIndex(db);
   });
 
   afterEach(async () => {
@@ -122,6 +125,7 @@ describe('SqliteNodeRepository', () => {
         data: n.data,
       });
       await repository.save(node);
+      await searchIndex.indexNode(node);
     }
     const { rows } = await db.run(sql`SELECT * FROM nodes_fts`);
 
@@ -136,6 +140,7 @@ describe('SqliteNodeRepository', () => {
         data: n.data,
       });
       await repository.save(node);
+      await searchIndex.indexNode(node);
     }
 
     const results = await repository.search('computers');
@@ -150,6 +155,7 @@ describe('SqliteNodeRepository', () => {
         data: n.data,
       });
       await repository.save(node);
+      await searchIndex.indexNode(node);
     }
 
     const results = await repository.search('irrelevant');

--- a/src/external/search-index/sqlite-search-index.ts
+++ b/src/external/search-index/sqlite-search-index.ts
@@ -1,0 +1,21 @@
+import { sql } from 'drizzle-orm';
+import type { DatabaseClient } from '../database/client.js';
+import type { SearchIndex } from '../../application/ports/search-index.js';
+import type { AnyNode } from '../../domain/types.js';
+
+class SqliteSearchIndex implements SearchIndex {
+  constructor(private readonly db: DatabaseClient) {}
+
+  async indexNode(node: AnyNode): Promise<void> {
+    await this.db.run(sql`DELETE FROM nodes_fts WHERE id = ${node.id}`);
+    await this.db.run(
+      sql`INSERT INTO nodes_fts(id, title, searchable_content, type) VALUES (${node.id}, ${node.title}, ${node.searchableContent}, ${node.type})`
+    );
+  }
+
+  async removeNode(id: string): Promise<void> {
+    await this.db.run(sql`DELETE FROM nodes_fts WHERE id = ${id}`);
+  }
+}
+
+export { SqliteSearchIndex };

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,6 +11,7 @@ import { PublishSiteUseCase } from './application/use-cases/publish-site.js';
 import { LinkNodesUseCase } from './application/use-cases/link-nodes.js';
 import { SearchNodesUseCase } from './application/use-cases/search-nodes.js';
 import { GenerateFlashcardsUseCase } from './application/use-cases/generate-flashcards.js';
+import { SqliteSearchIndex } from './external/search-index/sqlite-search-index.js';
 
 class Application {
   private cli: CLI;
@@ -23,11 +24,16 @@ class Application {
       process.env.DATABASE_URL || 'file:local.db'
     );
     const nodeRepository = new SqliteNodeRepository(db, nodeMapper);
+    const searchIndex = new SqliteSearchIndex(db);
     const htmlGenerator = new HTMLGenerator();
     const crawler = new HTTPCrawler();
     const flashcardGenerator = new OllamaFlashcardGenerator();
 
-    const createNode = new CreateNodeUseCase(nodeRepository, crawler);
+    const createNode = new CreateNodeUseCase(
+      nodeRepository,
+      crawler,
+      searchIndex
+    );
     const linkNodes = new LinkNodesUseCase(nodeRepository);
     const searchNodes = new SearchNodesUseCase(nodeRepository);
     const getNode = new GetNodeUseCase(nodeRepository);


### PR DESCRIPTION
## Summary
- add search index port and SQLite implementation using raw SQL
- expose searchableContent on nodes and index on creation
- expand nodes_fts table for type and searchable content

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68aae7b0b5d4832aa8a64c9a4f9d5782