### PR TITLE
feat: add flashcard review capability

### DIFF
--- a/drizzle/0002_add_flashcard_review.sql
+++ b/drizzle/0002_add_flashcard_review.sql
@@ -1,0 +1,9 @@
+ALTER TABLE `flashcard_nodes` ADD COLUMN `due_at` text NOT NULL DEFAULT (datetime('now'));
+--> statement-breakpoint
+ALTER TABLE `flashcard_nodes` ADD COLUMN `interval` integer NOT NULL DEFAULT 0;
+--> statement-breakpoint
+ALTER TABLE `flashcard_nodes` ADD COLUMN `ease_factor` real NOT NULL DEFAULT 2.5;
+--> statement-breakpoint
+ALTER TABLE `flashcard_nodes` ADD COLUMN `repetitions` integer NOT NULL DEFAULT 0;
+--> statement-breakpoint
+ALTER TABLE `flashcard_nodes` ADD COLUMN `last_reviewed_at` text;

--- a/drizzle/meta/0002_snapshot.json
+++ b/drizzle/meta/0002_snapshot.json
@@ -1,0 +1,388 @@
+{
+  "id": "33f83247-7b49-429d-8005-20937a5d3483",
+  "prevId": "8d957de6-ad13-4c2f-9a3b-9030924a77f8",
+  "version": "6",
+  "dialect": "sqlite",
+  "tables": {
+    "edges": {
+      "name": "edges",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "edges_source_idx": {
+          "name": "edges_source_idx",
+          "columns": ["source_id"],
+          "isUnique": false
+        },
+        "edges_target_idx": {
+          "name": "edges_target_idx",
+          "columns": ["target_id"],
+          "isUnique": false
+        },
+        "edges_unique_idx_source_target": {
+          "name": "edges_unique_idx_source_target",
+          "columns": ["source_id", "target_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "edges_source_id_nodes_id_fk": {
+          "name": "edges_source_id_nodes_id_fk",
+          "tableFrom": "edges",
+          "columnsFrom": ["source_id"],
+          "tableTo": "nodes",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "edges_target_id_nodes_id_fk": {
+          "name": "edges_target_id_nodes_id_fk",
+          "tableFrom": "edges",
+          "columnsFrom": ["target_id"],
+          "tableTo": "nodes",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "flashcard_nodes": {
+      "name": "flashcard_nodes",
+      "columns": {
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "front": {
+          "name": "front",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "back": {
+          "name": "back",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "due_at": {
+          "name": "due_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "interval": {
+          "name": "interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ease_factor": {
+          "name": "ease_factor",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repetitions": {
+          "name": "repetitions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_reviewed_at": {
+          "name": "last_reviewed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "flashcard_nodes_node_id_nodes_id_fk": {
+          "name": "flashcard_nodes_node_id_nodes_id_fk",
+          "tableFrom": "flashcard_nodes",
+          "columnsFrom": ["node_id"],
+          "tableTo": "nodes",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "link_nodes": {
+      "name": "link_nodes",
+      "columns": {
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "crawled_title": {
+          "name": "crawled_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "crawled_text": {
+          "name": "crawled_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "crawled_html": {
+          "name": "crawled_html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "link_nodes_url_unique": {
+          "name": "link_nodes_url_unique",
+          "columns": ["url"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "link_nodes_node_id_nodes_id_fk": {
+          "name": "link_nodes_node_id_nodes_id_fk",
+          "tableFrom": "link_nodes",
+          "columnsFrom": ["node_id"],
+          "tableTo": "nodes",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "nodes": {
+      "name": "nodes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "nodes_type_idx": {
+          "name": "nodes_type_idx",
+          "columns": ["type"],
+          "isUnique": false
+        },
+        "nodes_is_public_idx": {
+          "name": "nodes_is_public_idx",
+          "columns": ["is_public"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "note_nodes": {
+      "name": "note_nodes",
+      "columns": {
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "note_nodes_node_id_nodes_id_fk": {
+          "name": "note_nodes_node_id_nodes_id_fk",
+          "tableFrom": "note_nodes",
+          "columnsFrom": ["node_id"],
+          "tableTo": "nodes",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tag_nodes": {
+      "name": "tag_nodes",
+      "columns": {
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tag_nodes_name_unique": {
+          "name": "tag_nodes_name_unique",
+          "columns": ["name"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "tag_nodes_node_id_nodes_id_fk": {
+          "name": "tag_nodes_node_id_nodes_id_fk",
+          "tableFrom": "tag_nodes",
+          "columnsFrom": ["node_id"],
+          "tableTo": "nodes",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1756029801145,
       "tag": "0001_add_fts_to_nodes",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "6",
+      "when": 1756037834635,
+      "tag": "0002_add_flashcard_review",
+      "breakpoints": true
     }
   ]
 }

--- a/src/adapters/node-mapper.ts
+++ b/src/adapters/node-mapper.ts
@@ -133,6 +133,7 @@ const mappers = {
       }),
     toTypeRecord: (node: TagNode): Omit<TagNodeRecord, 'nodeId'> => ({
       name: node.data.name,
+      description: null,
     }),
   },
   flashcard: {
@@ -146,6 +147,13 @@ const mappers = {
         data: {
           front: record.flashcardNode.front,
           back: record.flashcardNode.back,
+          dueAt: new Date(record.flashcardNode.dueAt),
+          interval: record.flashcardNode.interval,
+          easeFactor: record.flashcardNode.easeFactor,
+          repetitions: record.flashcardNode.repetitions,
+          lastReviewedAt: record.flashcardNode.lastReviewedAt
+            ? new Date(record.flashcardNode.lastReviewedAt)
+            : null,
         },
       }),
     toTypeRecord: (
@@ -153,6 +161,13 @@ const mappers = {
     ): Omit<FlashcardNodeRecord, 'nodeId'> => ({
       front: node.data.front,
       back: node.data.back,
+      dueAt: node.data.dueAt.toISOString(),
+      interval: node.data.interval,
+      easeFactor: node.data.easeFactor,
+      repetitions: node.data.repetitions,
+      lastReviewedAt: node.data.lastReviewedAt
+        ? node.data.lastReviewedAt.toISOString()
+        : null,
     }),
   },
 } satisfies MapperConfig;

--- a/src/application/ports/node-repository.ts
+++ b/src/application/ports/node-repository.ts
@@ -1,4 +1,5 @@
 import type { AnyNode, NodeType, EdgeType } from '../../domain/types.js';
+import type { FlashcardNode } from '../../domain/flashcard-node.js';
 
 type SearchResult = {
   nodeId: string;
@@ -10,6 +11,7 @@ type SearchResult = {
 
 interface NodeRepository {
   save(node: AnyNode): Promise<void>;
+  update(node: AnyNode): Promise<void>;
   link(
     sourceId: string,
     targetId: string,
@@ -19,6 +21,7 @@ interface NodeRepository {
   findAll(): Promise<AnyNode[]>;
   findById(id: string, withRelations: boolean): Promise<AnyNode | null>;
   search(query: string): Promise<SearchResult[]>;
+  findDueFlashcards(date: Date, limit: number): Promise<FlashcardNode[]>;
 }
 
 export type { NodeRepository, SearchResult };

--- a/src/application/use-cases/create-node.test.ts
+++ b/src/application/use-cases/create-node.test.ts
@@ -7,10 +7,12 @@ import type { SearchIndex } from '../ports/search-index.js';
 
 const mockRepository: NodeRepository = {
   save: async (node: AnyNode) => Promise.resolve(),
+  update: async (node: AnyNode) => Promise.resolve(),
   findById: async (id: string) => Promise.resolve(null),
   findAll: async () => Promise.resolve([]),
   search: async (query: string) => Promise.resolve([]),
   link: async (sourceId: string, targetId: string, type?) => Promise.resolve(),
+  findDueFlashcards: async (date, limit) => Promise.resolve([]),
 };
 
 const mockCrawler: Crawler = {

--- a/src/application/use-cases/generate-flashcards.ts
+++ b/src/application/use-cases/generate-flashcards.ts
@@ -20,7 +20,7 @@ class GenerateFlashcardsUseCase {
     { ok: true; result: Array<Flashcard> } | { ok: false; error: string }
   > {
     try {
-      const node = await this.repository.findById(input.id);
+      const node = await this.repository.findById(input.id, false);
       if (!node) {
         return { ok: false, error: 'Node not found' };
       }

--- a/src/application/use-cases/get-due-flashcards.ts
+++ b/src/application/use-cases/get-due-flashcards.ts
@@ -1,0 +1,25 @@
+import type { NodeRepository } from '../ports/node-repository.js';
+import type { FlashcardNode } from '../../domain/flashcard-node.js';
+
+class GetDueFlashcardsUseCase {
+  constructor(private readonly repository: NodeRepository) {}
+
+  async execute(input: {
+    limit: number;
+    date?: Date;
+  }): Promise<
+    { ok: true; result: FlashcardNode[] } | { ok: false; error: string }
+  > {
+    try {
+      const cards = await this.repository.findDueFlashcards(
+        input.date ?? new Date(),
+        input.limit
+      );
+      return { ok: true, result: cards };
+    } catch (err) {
+      return { ok: false, error: (err as Error).message };
+    }
+  }
+}
+
+export { GetDueFlashcardsUseCase };

--- a/src/application/use-cases/get-node.ts
+++ b/src/application/use-cases/get-node.ts
@@ -12,7 +12,7 @@ class GetNodeUseCase {
     input: GetNodeInput
   ): Promise<{ ok: true; result: AnyNode } | { ok: false; error: string }> {
     try {
-      const result = await this.repository.findById(input.id);
+      const result = await this.repository.findById(input.id, false);
       if (!result) {
         return { ok: false, error: 'Node not found' };
       }

--- a/src/application/use-cases/link-nodes.ts
+++ b/src/application/use-cases/link-nodes.ts
@@ -4,7 +4,8 @@ import type { NodeRepository } from '../ports/node-repository.js';
 type LinkNodesInput = {
   sourceId: string;
   targetId: string;
-  type?: EdgeType;
+  type: EdgeType;
+  isBidirectional?: boolean;
 };
 
 class LinkNodesUseCase {
@@ -12,7 +13,12 @@ class LinkNodesUseCase {
 
   async execute(input: LinkNodesInput) {
     try {
-      await this.repository.link(input.sourceId, input.targetId, input.type);
+      await this.repository.link(
+        input.sourceId,
+        input.targetId,
+        input.type,
+        input.isBidirectional ?? false
+      );
       return { ok: true as const };
     } catch (err) {
       return { ok: false as const, error: (err as Error).message };

--- a/src/application/use-cases/review-flashcard.ts
+++ b/src/application/use-cases/review-flashcard.ts
@@ -1,0 +1,23 @@
+import type { NodeRepository } from '../ports/node-repository.js';
+import type { FlashcardNode } from '../../domain/flashcard-node.js';
+
+class ReviewFlashcardUseCase {
+  constructor(private readonly repository: NodeRepository) {}
+
+  async execute(input: {
+    flashcard: FlashcardNode;
+    quality: number;
+  }): Promise<
+    { ok: true; result: FlashcardNode } | { ok: false; error: string }
+  > {
+    try {
+      const updated = input.flashcard.review(input.quality);
+      await this.repository.update(updated);
+      return { ok: true, result: updated };
+    } catch (err) {
+      return { ok: false, error: (err as Error).message };
+    }
+  }
+}
+
+export { ReviewFlashcardUseCase };

--- a/src/domain/flashcard-node.test.ts
+++ b/src/domain/flashcard-node.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { FlashcardNode } from './flashcard-node.js';
+
+describe('FlashcardNode', () => {
+  it('initializes review fields on create', () => {
+    const card = FlashcardNode.create({
+      isPublic: false,
+      data: { front: 'front', back: 'back' },
+    });
+    expect(card.data.repetitions).toBe(0);
+    expect(card.data.interval).toBe(0);
+    expect(card.data.easeFactor).toBe(2.5);
+    expect(card.data.lastReviewedAt).toBeNull();
+  });
+
+  it('updates scheduling on review', () => {
+    const card = FlashcardNode.create({
+      isPublic: false,
+      data: { front: 'q', back: 'a' },
+    });
+    const reviewed = card.review(5);
+    expect(reviewed.data.repetitions).toBe(1);
+    expect(reviewed.data.interval).toBe(1);
+    expect(reviewed.data.dueAt.getTime()).toBeGreaterThan(
+      card.data.dueAt.getTime()
+    );
+    expect(reviewed.data.lastReviewedAt).not.toBeNull();
+  });
+});

--- a/src/external/ai-services/ollama-flashcard-generator.ts
+++ b/src/external/ai-services/ollama-flashcard-generator.ts
@@ -73,16 +73,17 @@ class OllamaFlashcardGenerator implements FlashcardGenerator {
 
       if (
         (!response.message?.tool_calls ||
-          response.message.tool_calls.length === 0) &&
+          response.message?.tool_calls?.length === 0) &&
         isDone
       ) {
         break;
       }
 
       // Execute any tool calls it requested
-      if (response.message?.tool_calls?.length) {
+      const toolCalls = response.message?.tool_calls ?? [];
+      if (toolCalls.length) {
         messages.push(response.message);
-        for (const call of response.message.tool_calls) {
+        for (const call of toolCalls) {
           if (call.function?.name === 'create_flashcard') {
             const card = call.function.arguments as Flashcard;
             console.log(card);

--- a/src/external/database/schema.ts
+++ b/src/external/database/schema.ts
@@ -3,6 +3,7 @@ import {
   sqliteTable,
   text,
   integer,
+  real,
   index,
   unique,
 } from 'drizzle-orm/sqlite-core';
@@ -68,6 +69,11 @@ const flashcardNodesTable = sqliteTable('flashcard_nodes', {
     .references(() => nodesTable.id, { onDelete: 'cascade' }),
   front: text('front').notNull(),
   back: text('back').notNull(),
+  dueAt: text('due_at').notNull(),
+  interval: integer('interval').notNull(),
+  easeFactor: real('ease_factor').notNull(),
+  repetitions: integer('repetitions').notNull(),
+  lastReviewedAt: text('last_reviewed_at'),
 });
 
 const edgesTable = sqliteTable(

--- a/src/external/repositories/sqlite-node-repository.ts
+++ b/src/external/repositories/sqlite-node-repository.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from 'node:crypto';
-import { eq, or, inArray, sql } from 'drizzle-orm';
+import { eq, or, inArray, sql, lte, asc } from 'drizzle-orm';
 import { NodeMapper } from '../../adapters/node-mapper.js';
 import {
   nodesTable,
@@ -15,6 +15,7 @@ import type {
   SearchResult,
 } from '../../application/ports/node-repository.js';
 import type { AnyNode, NodeType, EdgeType } from '../../domain/types.js';
+import type { FlashcardNode } from '../../domain/flashcard-node.js';
 
 const typeTableLookup: Record<
   NodeType,
@@ -41,6 +42,67 @@ class SqliteNodeRepository implements NodeRepository {
     await this.db.transaction(async (tx) => {
       await tx.insert(nodesTable).values(bundle.nodeRecord);
       await tx.insert(typeTableLookup[bundle.type]).values(bundle.typeRecord);
+    });
+  }
+
+  async update(node: AnyNode): Promise<void> {
+    const bundle = this.mapper.toRecords(node);
+
+    await this.db.transaction(async (tx) => {
+      await tx
+        .update(nodesTable)
+        .set({
+          type: bundle.nodeRecord.type,
+          title: bundle.nodeRecord.title,
+          version: bundle.nodeRecord.version,
+          isPublic: bundle.nodeRecord.isPublic,
+          createdAt: bundle.nodeRecord.createdAt,
+          updatedAt: bundle.nodeRecord.updatedAt,
+        })
+        .where(eq(nodesTable.id, bundle.nodeRecord.id));
+
+      switch (bundle.type) {
+        case 'note':
+          await tx
+            .update(noteNodesTable)
+            .set({ content: bundle.typeRecord.content })
+            .where(eq(noteNodesTable.nodeId, node.id));
+          break;
+        case 'link':
+          await tx
+            .update(linkNodesTable)
+            .set({
+              url: bundle.typeRecord.url,
+              crawledTitle: bundle.typeRecord.crawledTitle,
+              crawledText: bundle.typeRecord.crawledText,
+              crawledHtml: bundle.typeRecord.crawledHtml,
+            })
+            .where(eq(linkNodesTable.nodeId, node.id));
+          break;
+        case 'tag':
+          await tx
+            .update(tagNodesTable)
+            .set({
+              name: bundle.typeRecord.name,
+              description: bundle.typeRecord.description,
+            })
+            .where(eq(tagNodesTable.nodeId, node.id));
+          break;
+        case 'flashcard':
+          await tx
+            .update(flashcardNodesTable)
+            .set({
+              front: bundle.typeRecord.front,
+              back: bundle.typeRecord.back,
+              dueAt: bundle.typeRecord.dueAt,
+              interval: bundle.typeRecord.interval,
+              easeFactor: bundle.typeRecord.easeFactor,
+              repetitions: bundle.typeRecord.repetitions,
+              lastReviewedAt: bundle.typeRecord.lastReviewedAt,
+            })
+            .where(eq(flashcardNodesTable.nodeId, node.id));
+          break;
+      }
     });
   }
 
@@ -172,6 +234,23 @@ class SqliteNodeRepository implements NodeRepository {
       snippet: row.snippet,
       score: Number(row.score),
     }));
+  }
+
+  async findDueFlashcards(date: Date, limit: number): Promise<FlashcardNode[]> {
+    const records = await this.db.query.flashcardNodesTable.findMany({
+      where: lte(flashcardNodesTable.dueAt, date.toISOString()),
+      with: { node: true },
+      orderBy: asc(flashcardNodesTable.dueAt),
+      limit,
+    });
+
+    return records.map((r) => {
+      const node = this.mapper.toDomain({ ...r.node, flashcardNode: r });
+      if (node.type !== 'flashcard') {
+        throw new Error('Expected flashcard node');
+      }
+      return node;
+    });
   }
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,6 +11,8 @@ import { PublishSiteUseCase } from './application/use-cases/publish-site.js';
 import { LinkNodesUseCase } from './application/use-cases/link-nodes.js';
 import { SearchNodesUseCase } from './application/use-cases/search-nodes.js';
 import { GenerateFlashcardsUseCase } from './application/use-cases/generate-flashcards.js';
+import { GetDueFlashcardsUseCase } from './application/use-cases/get-due-flashcards.js';
+import { ReviewFlashcardUseCase } from './application/use-cases/review-flashcard.js';
 import { SqliteSearchIndex } from './external/search-index/sqlite-search-index.js';
 
 class Application {
@@ -46,13 +48,17 @@ class Application {
       htmlGenerator,
       './public'
     );
+    const getDueFlashcards = new GetDueFlashcardsUseCase(nodeRepository);
+    const reviewFlashcard = new ReviewFlashcardUseCase(nodeRepository);
     this.cli = new CLI(
       createNode,
       linkNodes,
       searchNodes,
       getNode,
       generateFlashcards,
-      publishSite
+      publishSite,
+      getDueFlashcards,
+      reviewFlashcard
     );
   }
 


### PR DESCRIPTION
## Summary
- add spaced-repetition fields and review logic to flashcard nodes
- extend repositories and CLI to fetch and review due flashcards
- record flashcard review data in database schema and migrations

## Testing
- `pnpm typecheck`
- `pnpm test --run`


------
https://chatgpt.com/codex/tasks/task_e_68ab00488aa8832a8b9d6917b804022d