### PR TITLE
test: split search nodes tests into unit and integration

### DIFF
--- a/src/application/use-cases/search-nodes.integration.test.ts
+++ b/src/application/use-cases/search-nodes.integration.test.ts
@@ -1,0 +1,129 @@
+import os from 'node:os';
+import path from 'node:path';
+import fs from 'node:fs/promises';
+import { randomUUID } from 'node:crypto';
+import { describe, test, beforeEach, afterEach, expect } from 'vitest';
+import { migrate } from 'drizzle-orm/libsql/migrator';
+import { createDatabaseClient, type DatabaseClient } from '../../external/database/client.js';
+import { NodeMapper } from '../../adapters/node-mapper.js';
+import { SqliteNodeRepository } from '../../external/repositories/sqlite-node-repository.js';
+import { SqliteSearchIndex } from '../../external/search-index/sqlite-search-index.js';
+import { SearchNodesUseCase } from './search-nodes.js';
+import { NoteNode } from '../../domain/note-node.js';
+import { LinkNode } from '../../domain/link-node.js';
+
+function assertOk<T>(
+  result: { ok: true; result: T } | { ok: false; error: string }
+): asserts result is { ok: true; result: T } {
+  expect(result.ok).toBe(true);
+  if (!result.ok) throw new Error(result.error);
+}
+
+function first<T>(arr: readonly T[]): T {
+  const item = arr[0];
+  if (item === undefined) throw new Error('expected at least one item');
+  return item;
+}
+
+describe('SearchNodesUseCase (integration)', () => {
+  let db: DatabaseClient;
+  let dbFile: string;
+  let repository: SqliteNodeRepository;
+  let searchIndex: SqliteSearchIndex;
+  let useCase: SearchNodesUseCase;
+
+  beforeEach(async () => {
+    dbFile = path.join(os.tmpdir(), `${randomUUID()}.db`);
+    db = createDatabaseClient(`file:${dbFile}`);
+    await migrate(db, { migrationsFolder: './drizzle' });
+    repository = new SqliteNodeRepository(db, new NodeMapper());
+    searchIndex = new SqliteSearchIndex(db);
+    useCase = new SearchNodesUseCase(repository);
+  });
+
+  afterEach(async () => {
+    try {
+      await fs.unlink(dbFile);
+    } catch {}
+  });
+
+  test('returns matching nodes for query', async () => {
+    const note = NoteNode.create({
+      title: 'Test Note',
+      isPublic: false,
+      data: { content: 'Some important content' },
+    });
+    await repository.save(note);
+    await searchIndex.indexNode(note);
+
+    const result = await useCase.execute({ query: 'important' });
+    assertOk(result);
+    const hit = first(result.result);
+    expect(hit.node.id).toBe(note.id);
+  });
+
+  test('returns multiple node types', async () => {
+    const note = NoteNode.create({
+      title: 'Computer Science',
+      isPublic: false,
+      data: { content: 'Study of computers' },
+    });
+    const link = LinkNode.create({
+      title: 'CS Resource',
+      isPublic: true,
+      data: {
+        url: 'https://example.com',
+        crawled: { title: 'Computer Science Guide', text: 'Guide', html: '<p>Guide</p>' },
+      },
+    });
+
+    await repository.save(note);
+    await repository.save(link);
+    await searchIndex.indexNode(note);
+    await searchIndex.indexNode(link);
+
+    const result = await useCase.execute({ query: 'computer' });
+    assertOk(result);
+    expect(result.result).toHaveLength(2);
+    const types = result.result.map((r) => r.node.type).sort();
+    expect(types).toEqual(['link', 'note']);
+  });
+
+  test('includes related nodes when requested', async () => {
+    const parent = NoteNode.create({
+      title: 'Parent',
+      isPublic: false,
+      data: { content: 'Parent content' },
+    });
+    const child = NoteNode.create({
+      title: 'Child',
+      isPublic: false,
+      data: { content: 'Child content' },
+    });
+    await repository.save(parent);
+    await repository.save(child);
+    await repository.link(parent.id, child.id, 'contains', false);
+    await searchIndex.indexNode(parent);
+    await searchIndex.indexNode(child);
+
+    const result = await useCase.execute({ query: 'Parent', withRelations: true });
+    assertOk(result);
+    const hit = first(result.result);
+    const related = first(hit.node.relatedNodes);
+    expect(related.node.id).toBe(child.id);
+  });
+
+  test('returns empty array for unmatched query', async () => {
+    const note = NoteNode.create({
+      title: 'Topic',
+      isPublic: false,
+      data: { content: 'Something else' },
+    });
+    await repository.save(note);
+    await searchIndex.indexNode(note);
+
+    const result = await useCase.execute({ query: 'unrelated' });
+    assertOk(result);
+    expect(result.result).toEqual([]);
+  });
+});

--- a/src/application/use-cases/search-nodes.test.ts
+++ b/src/application/use-cases/search-nodes.test.ts
@@ -1,259 +1,65 @@
-import os from 'node:os';
-import path from 'node:path';
-import { randomUUID } from 'node:crypto';
 import { describe, test, expect, vi, beforeEach } from 'vitest';
-import { migrate } from 'drizzle-orm/libsql/migrator';
 import { SearchNodesUseCase } from './search-nodes.js';
 import { NoteNode } from '../../domain/note-node.js';
-import { LinkNode } from '../../domain/link-node.js';
-import { createDatabaseClient } from '../../external/database/client.js';
-import { NodeMapper } from '../../adapters/node-mapper.js';
-import { SqliteNodeRepository } from '../../external/repositories/sqlite-node-repository.js';
-import { SqliteSearchIndex } from '../../external/search-index/sqlite-search-index.js';
 import type { NodeRepository, SearchResult } from '../ports/node-repository.js';
+
+function assertOk<T>(
+  result: { ok: true; result: T } | { ok: false; error: string }
+): asserts result is { ok: true; result: T } {
+  expect(result.ok).toBe(true);
+  if (!result.ok) throw new Error(result.error);
+}
 
 describe('SearchNodesUseCase', () => {
   let repository: NodeRepository;
   let useCase: SearchNodesUseCase;
 
-  beforeEach(async () => {
-    // TODO: move this code to some helper as it is used everywhere!
-    const dbFile = path.join(os.tmpdir(), `${randomUUID()}.db`);
-    const db = createDatabaseClient(`file:${dbFile}`);
-    await migrate(db, { migrationsFolder: './drizzle' });
-
-    const mapper = new NodeMapper();
-    repository = new SqliteNodeRepository(db, mapper);
+  beforeEach(() => {
+    repository = {
+      search: vi.fn(),
+    } as unknown as NodeRepository;
     useCase = new SearchNodesUseCase(repository);
   });
 
-  test('returns empty results for empty query', async () => {
-    const result = await useCase.execute({ query: '' });
-
-    expect(result.ok).toBe(true);
-    if (result.ok) {
-      expect(result.result).toEqual([]);
-    }
+  test('returns empty results for blank query without calling repository', async () => {
+    const result = await useCase.execute({ query: '   ' });
+    assertOk(result);
+    expect(result.result).toEqual([]);
     expect(repository.search).not.toHaveBeenCalled();
   });
 
-  test('returns empty results for single character query', async () => {
-    // vi.mocked(mockRepository.search).mockRejectedValue(
-    //   new Error('search should not be called')
-    // );
-
-    const result = await useCase.execute({ query: 'm' });
-
-    expect(result.ok).toBe(true);
-    if (result.ok) {
-      expect(result.result).toEqual([]);
-    }
-    expect(repository.search).not.toHaveBeenCalled();
-  });
-
-  test('returns search results without relations by default', async () => {
+  test('delegates search to repository', async () => {
     const note = NoteNode.create({
-      title: 'Test Note',
+      title: 'Test',
       isPublic: false,
-      data: { content: 'Test content' },
+      data: { content: 'content' },
     });
-
     const mockResults: SearchResult[] = [
-      {
-        node: note,
-        snippet: 'Test <b>content</b>',
-        score: 0.95,
-      },
+      { node: note, snippet: 'content', score: 1 },
     ];
-
-    // vi.mocked(repository.search).mockResolvedValue(mockResults);
+    vi.mocked(repository.search).mockResolvedValue(mockResults);
 
     const result = await useCase.execute({ query: 'content' });
-
-    expect(result.ok).toBe(true);
-    if (result.ok) {
-      expect(result.result).toEqual(mockResults);
-    }
+    assertOk(result);
+    expect(result.result).toEqual(mockResults);
     expect(repository.search).toHaveBeenCalledWith('content', undefined);
   });
 
-  test('returns search results with relations when requested', async () => {
-    const parentNote = NoteNode.create({
-      title: 'Parent Note',
-      isPublic: false,
-      data: { content: 'Parent content' },
-    });
+  test('passes relation flag to repository', async () => {
+    vi.mocked(repository.search).mockResolvedValue([]);
 
-    const childNote = NoteNode.create({
-      title: 'Child Note',
-      isPublic: false,
-      data: { content: 'Child content' },
-    });
-
-    // Set up the relationship
-    const relatedMap = new Map();
-    relatedMap.set(childNote.id, {
-      node: childNote,
-      relationship: {
-        type: 'contains',
-        direction: 'from',
-      },
-    });
-    parentNote.setRelatedNodes(relatedMap);
-
-    const mockResults: SearchResult[] = [
-      {
-        node: parentNote,
-        snippet: '<b>Parent</b> content',
-        score: 0.9,
-      },
-    ];
-
-    /// vi.mocked(repository.search).mockResolvedValue(mockResults);
-
-    const result = await useCase.execute({
-      query: 'parent',
-      withRelations: true,
-    });
-
-    expect(result.ok).toBe(true);
-    if (result.ok) {
-      expect(result.result).toEqual(mockResults);
-      expect(result.result[0].node.relatedNodes).toHaveLength(1);
-      expect(result.result[0].node.relatedNodes[0].node.id).toBe(childNote.id);
-    }
-    expect(repository.search).toHaveBeenCalledWith('parent', true);
+    const result = await useCase.execute({ query: 'x', withRelations: true });
+    assertOk(result);
+    expect(repository.search).toHaveBeenCalledWith('x', true);
   });
 
-  test('handles repository errors gracefully', async () => {
-    // vi.mocked(repository.search).mockRejectedValue(
-    //   new Error('Database connection failed')
-    // );
+  test('returns error when repository throws', async () => {
+    vi.mocked(repository.search).mockRejectedValue(new Error('db error'));
 
     const result = await useCase.execute({ query: 'test' });
-
     expect(result.ok).toBe(false);
     if (!result.ok) {
-      expect(result.error).toBe('Database connection failed');
-    }
-  });
-
-  test('handles multiple node types in results', async () => {
-    const note = NoteNode.create({
-      title: 'Computer Science',
-      isPublic: false,
-      data: { content: 'Study of computers' },
-    });
-
-    const link = LinkNode.create({
-      title: 'CS Resource',
-      isPublic: true,
-      data: {
-        url: 'https://example.com',
-        crawled: {
-          title: 'Computer Science Guide',
-          text: 'Complete guide to CS',
-          html: '<p>Complete guide to CS</p>',
-        },
-      },
-    });
-
-    const mockResults: SearchResult[] = [
-      {
-        node: note,
-        snippet: 'Study of <b>computers</b>',
-        score: 0.95,
-      },
-      {
-        node: link,
-        snippet: '<b>Computer</b> Science Guide',
-        score: 0.85,
-      },
-    ];
-
-    // vi.mocked(repository.search).mockResolvedValue(mockResults);
-
-    const result = await useCase.execute({ query: 'computer' });
-
-    expect(result.ok).toBe(true);
-    if (result.ok) {
-      expect(result.result).toHaveLength(2);
-      expect(result.result[0].node.type).toBe('note');
-      expect(result.result[1].node.type).toBe('link');
-    }
-  });
-
-  test('preserves score ordering from repository', async () => {
-    const highScoreNode = NoteNode.create({
-      title: 'Exact Match',
-      isPublic: false,
-      data: { content: 'quantum computing' },
-    });
-
-    const mediumScoreNode = NoteNode.create({
-      title: 'Partial Match',
-      isPublic: false,
-      data: { content: 'quantum mechanics and computing' },
-    });
-
-    const lowScoreNode = NoteNode.create({
-      title: 'Weak Match',
-      isPublic: false,
-      data: { content: 'classical computing with quantum inspirations' },
-    });
-
-    const mockResults: SearchResult[] = [
-      { node: highScoreNode, snippet: '<b>quantum computing</b>', score: 0.99 },
-      {
-        node: mediumScoreNode,
-        snippet: '<b>quantum</b> mechanics',
-        score: 0.75,
-      },
-      {
-        node: lowScoreNode,
-        snippet: 'classical <b>computing</b>',
-        score: 0.45,
-      },
-    ];
-
-    // vi.mocked(repository.search).mockResolvedValue(mockResults);
-
-    const result = await useCase.execute({ query: 'quantum computing' });
-
-    expect(result.ok).toBe(true);
-    if (result.ok) {
-      expect(result.result[0].score).toBe(0.99);
-      expect(result.result[1].score).toBe(0.75);
-      expect(result.result[2].score).toBe(0.45);
-    }
-  });
-});
-
-describe('SearchNodesUseCase - Integration', () => {
-  test('demonstrates missing automatic indexing (will fail without fix)', async () => {
-    // TODO: move this code to some helper as it is used everywhere!
-    const dbFile = path.join(os.tmpdir(), `${randomUUID()}.db`);
-    const db = createDatabaseClient(`file:${dbFile}`);
-    await migrate(db, { migrationsFolder: './drizzle' });
-
-    const mapper = new NodeMapper();
-    const repository = new SqliteNodeRepository(db, mapper);
-    const searchIndex = new SqliteSearchIndex(db);
-    const useCase = new SearchNodesUseCase(repository);
-
-    const note = NoteNode.create({
-      title: 'Test Note',
-      isPublic: false,
-      data: { content: 'Important content to search' },
-    });
-    await repository.save(note);
-    await searchIndex.indexNode(note);
-
-    const result = await useCase.execute({ query: 'important' });
-
-    expect(result.ok).toBe(true);
-    if (result.ok) {
-      expect(result.result).toHaveLength(1);
+      expect(result.error).toBe('db error');
     }
   });
 });


### PR DESCRIPTION
## Summary
- split search-nodes tests into unit and integration suites
- unit tests mock NodeRepository and remove defensive type checks via assert helper
- integration tests exercise real SQLite DB and relations

## Testing
- `pnpm typecheck` *(fails: src/adapters/node-mapper.ts:134: Type 'string | null' is not assignable to type 'string')*
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68ac741efe94832a9c2430efa9514ffa