### PR TITLE
test: add GetNode use case tests

### DIFF
--- a/src/application/use-cases/get-node.integration.test.ts
+++ b/src/application/use-cases/get-node.integration.test.ts
@@ -1,0 +1,80 @@
+import os from 'node:os';
+import path from 'node:path';
+import fs from 'node:fs/promises';
+import { randomUUID } from 'node:crypto';
+import { describe, test, beforeEach, afterEach, expect } from 'vitest';
+import { migrate } from 'drizzle-orm/libsql/migrator';
+import { createDatabaseClient, type DatabaseClient } from '../../external/database/client.js';
+import { NodeMapper } from '../../adapters/node-mapper.js';
+import { SqliteNodeRepository } from '../../external/repositories/sqlite-node-repository.js';
+import { GetNodeUseCase } from './get-node.js';
+import { NoteNode } from '../../domain/note-node.js';
+
+function assertOk<T>(
+  result: { ok: true; result: T } | { ok: false; error: string }
+): asserts result is { ok: true; result: T } {
+  expect(result.ok).toBe(true);
+  if (!result.ok) throw new Error(result.error);
+}
+
+describe('GetNodeUseCase (integration)', () => {
+  let db: DatabaseClient;
+  let dbFile: string;
+  let repository: SqliteNodeRepository;
+  let useCase: GetNodeUseCase;
+
+  beforeEach(async () => {
+    dbFile = path.join(os.tmpdir(), `${randomUUID()}.db`);
+    db = createDatabaseClient(`file:${dbFile}`);
+    await migrate(db, { migrationsFolder: './drizzle' });
+    repository = new SqliteNodeRepository(db, new NodeMapper());
+    useCase = new GetNodeUseCase(repository);
+  });
+
+  afterEach(async () => {
+    try {
+      await fs.unlink(dbFile);
+    } catch {}
+  });
+
+  test('retrieves node by id', async () => {
+    const note = NoteNode.create({
+      title: 'Test',
+      isPublic: false,
+      data: { content: 'content' },
+    });
+    await repository.save(note);
+
+    const result = await useCase.execute({ id: note.id });
+    assertOk(result);
+    expect(result.result.id).toBe(note.id);
+  });
+
+  test('returns error when node does not exist', async () => {
+    const result = await useCase.execute({ id: randomUUID() });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBe('Node not found');
+    }
+  });
+
+  test('does not include related nodes by default', async () => {
+    const parent = NoteNode.create({
+      title: 'Parent',
+      isPublic: false,
+      data: { content: 'parent' },
+    });
+    const child = NoteNode.create({
+      title: 'Child',
+      isPublic: false,
+      data: { content: 'child' },
+    });
+    await repository.save(parent);
+    await repository.save(child);
+    await repository.link(parent.id, child.id, 'contains', false);
+
+    const result = await useCase.execute({ id: parent.id });
+    assertOk(result);
+    expect(result.result.relatedNodes).toHaveLength(0);
+  });
+});

--- a/src/application/use-cases/get-node.test.ts
+++ b/src/application/use-cases/get-node.test.ts
@@ -1,0 +1,57 @@
+import { describe, test, expect, vi, beforeEach } from 'vitest';
+import { GetNodeUseCase } from './get-node.js';
+import { NoteNode } from '../../domain/note-node.js';
+import type { NodeRepository } from '../ports/node-repository.js';
+
+function assertOk<T>(
+  result: { ok: true; result: T } | { ok: false; error: string }
+): asserts result is { ok: true; result: T } {
+  expect(result.ok).toBe(true);
+  if (!result.ok) throw new Error(result.error);
+}
+
+describe('GetNodeUseCase', () => {
+  let repository: NodeRepository;
+  let useCase: GetNodeUseCase;
+
+  beforeEach(() => {
+    repository = {
+      findById: vi.fn(),
+    } as unknown as NodeRepository;
+    useCase = new GetNodeUseCase(repository);
+  });
+
+  test('returns node when found', async () => {
+    const note = NoteNode.create({
+      title: 'Test',
+      isPublic: false,
+      data: { content: 'content' },
+    });
+    vi.mocked(repository.findById).mockResolvedValue(note);
+
+    const result = await useCase.execute({ id: note.id });
+    assertOk(result);
+    expect(result.result).toBe(note);
+    expect(repository.findById).toHaveBeenCalledWith(note.id, false);
+  });
+
+  test('returns error when node not found', async () => {
+    vi.mocked(repository.findById).mockResolvedValue(null);
+
+    const result = await useCase.execute({ id: 'missing' });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBe('Node not found');
+    }
+  });
+
+  test('returns error when repository throws', async () => {
+    vi.mocked(repository.findById).mockRejectedValue(new Error('db error'));
+
+    const result = await useCase.execute({ id: 'x' });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBe('db error');
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for GetNodeUseCase covering success, not found, and repository error cases
- add integration tests verifying node retrieval and relation omission

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac8a214abc832abee9e2edf99e4484