### PR TITLE
feat: add flashcard answer grading

### DIFF
--- a/src/application/ports/flashcard-answer-grader.ts
+++ b/src/application/ports/flashcard-answer-grader.ts
@@ -1,0 +1,14 @@
+type FlashcardAnswerEvaluation = {
+  score: 0 | 0.5 | 1;
+  comment: string;
+};
+
+interface FlashcardAnswerGrader {
+  evaluate(input: {
+    front: string;
+    back: string;
+    answer: string;
+  }): Promise<FlashcardAnswerEvaluation>;
+}
+
+export type { FlashcardAnswerGrader, FlashcardAnswerEvaluation };

--- a/src/application/use-cases/evaluate-flashcard-answer.ts
+++ b/src/application/use-cases/evaluate-flashcard-answer.ts
@@ -1,0 +1,25 @@
+import type {
+  FlashcardAnswerGrader,
+  FlashcardAnswerEvaluation,
+} from '../ports/flashcard-answer-grader.js';
+
+class EvaluateFlashcardAnswerUseCase {
+  constructor(private readonly grader: FlashcardAnswerGrader) {}
+
+  async execute(input: {
+    front: string;
+    back: string;
+    answer: string;
+  }): Promise<
+    { ok: true; result: FlashcardAnswerEvaluation } | { ok: false; error: string }
+  > {
+    try {
+      const evaluation = await this.grader.evaluate(input);
+      return { ok: true, result: evaluation };
+    } catch (err) {
+      return { ok: false, error: (err as Error).message };
+    }
+  }
+}
+
+export { EvaluateFlashcardAnswerUseCase };

--- a/src/external/ai-services/mock-flashcard-answer-grader.ts
+++ b/src/external/ai-services/mock-flashcard-answer-grader.ts
@@ -1,0 +1,20 @@
+import type {
+  FlashcardAnswerGrader,
+  FlashcardAnswerEvaluation,
+} from '../../application/ports/flashcard-answer-grader.js';
+
+class MockFlashcardAnswerGrader implements FlashcardAnswerGrader {
+  async evaluate(input: {
+    front: string;
+    back: string;
+    answer: string;
+  }): Promise<FlashcardAnswerEvaluation> {
+    const normalizedBack = input.back.trim().toLowerCase();
+    const normalizedAnswer = input.answer.trim().toLowerCase();
+    const score = normalizedBack === normalizedAnswer ? 1 : 0;
+    const comment = score === 1 ? 'Exact match' : 'Incorrect';
+    return { score, comment };
+  }
+}
+
+export { MockFlashcardAnswerGrader };

--- a/src/external/ai-services/ollama-flashcard-answer-grader.ts
+++ b/src/external/ai-services/ollama-flashcard-answer-grader.ts
@@ -1,0 +1,58 @@
+import ollama from 'ollama';
+import type {
+  FlashcardAnswerGrader,
+  FlashcardAnswerEvaluation,
+} from '../../application/ports/flashcard-answer-grader.js';
+
+class OllamaFlashcardAnswerGrader implements FlashcardAnswerGrader {
+  async evaluate(input: {
+    front: string;
+    back: string;
+    answer: string;
+  }): Promise<FlashcardAnswerEvaluation> {
+    const messages = [
+      {
+        role: 'system',
+        content:
+          'You grade flashcard answers. Respond in JSON with keys `score` (0, 0.5, or 1) and `comment`. ',
+      },
+      {
+        role: 'user',
+        content:
+          `Front: ${input.front}\nCorrect Answer: ${input.back}\nUser Answer: ${input.answer}`,
+      },
+    ];
+    const response = await ollama.chat({
+      model: 'gpt-oss:20b',
+      messages,
+      format: 'json',
+    });
+    const content = response.message?.content ?? '{}';
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(content);
+    } catch {
+      return { score: 0, comment: 'Failed to parse model response' };
+    }
+    if (
+      typeof parsed === 'object' &&
+      parsed !== null &&
+      'score' in parsed &&
+      'comment' in parsed
+    ) {
+      const obj = parsed as { score: unknown; comment: unknown };
+      if (
+        (obj.score === 0 || obj.score === 0.5 || obj.score === 1) &&
+        typeof obj.comment === 'string'
+      ) {
+        return {
+          score: obj.score,
+          comment: obj.comment,
+        };
+      }
+    }
+    return { score: 0, comment: 'Invalid model response' };
+  }
+}
+
+export { OllamaFlashcardAnswerGrader };

--- a/src/external/cli/cli.ts
+++ b/src/external/cli/cli.ts
@@ -8,6 +8,7 @@ import type { GenerateFlashcardsUseCase } from '../../application/use-cases/gene
 import type { PublishSiteUseCase } from '../../application/use-cases/publish-site.js';
 import type { GetDueFlashcardsUseCase } from '../../application/use-cases/get-due-flashcards.js';
 import type { ReviewFlashcardUseCase } from '../../application/use-cases/review-flashcard.js';
+import type { EvaluateFlashcardAnswerUseCase } from '../../application/use-cases/evaluate-flashcard-answer.js';
 import { CreateCommand } from './commands/create.js';
 import { SearchCommand } from './commands/search.js';
 import { GenerateFlashcardsCommand } from './commands/generate-flashcards.js';
@@ -25,7 +26,8 @@ class CLI {
     generateFlashcardsUseCase: GenerateFlashcardsUseCase,
     publishSiteUseCase: PublishSiteUseCase,
     getDueFlashcardsUseCase: GetDueFlashcardsUseCase,
-    reviewFlashcardUseCase: ReviewFlashcardUseCase
+    reviewFlashcardUseCase: ReviewFlashcardUseCase,
+    evaluateFlashcardAnswerUseCase: EvaluateFlashcardAnswerUseCase
   ) {
     this.program = new Command();
     this.program
@@ -52,7 +54,8 @@ class CLI {
 
     new ReviewCommand(
       getDueFlashcardsUseCase,
-      reviewFlashcardUseCase
+      reviewFlashcardUseCase,
+      evaluateFlashcardAnswerUseCase
     ).register(this.program);
   }
 

--- a/src/external/cli/commands/review.ts
+++ b/src/external/cli/commands/review.ts
@@ -2,11 +2,13 @@ import { Command } from 'commander';
 import { select, input } from '@inquirer/prompts';
 import type { GetDueFlashcardsUseCase } from '../../../application/use-cases/get-due-flashcards.js';
 import type { ReviewFlashcardUseCase } from '../../../application/use-cases/review-flashcard.js';
+import type { EvaluateFlashcardAnswerUseCase } from '../../../application/use-cases/evaluate-flashcard-answer.js';
 
 class ReviewCommand {
   constructor(
     private readonly getDueFlashcardsUseCase: GetDueFlashcardsUseCase,
-    private readonly reviewFlashcardUseCase: ReviewFlashcardUseCase
+    private readonly reviewFlashcardUseCase: ReviewFlashcardUseCase,
+    private readonly evaluateFlashcardAnswerUseCase: EvaluateFlashcardAnswerUseCase
   ) {}
 
   register(program: Command): void {
@@ -34,7 +36,24 @@ class ReviewCommand {
     for (const [i, card] of cards.entries()) {
       console.log(`\n📚 Card ${i + 1} of ${cards.length}`);
       console.log(`Front: ${card.data.front}`);
-      await input({ message: 'Press enter to reveal the back' });
+      const answer = await input({
+        message: 'Type your answer (leave empty to skip):',
+      });
+      if (answer.trim() !== '') {
+        const evaluation = await this.evaluateFlashcardAnswerUseCase.execute({
+          front: card.data.front,
+          back: card.data.back,
+          answer,
+        });
+        if (evaluation.ok) {
+          const score = evaluation.result.score;
+          const label =
+            score === 1 ? '✅ Correct' : score === 0.5 ? '⚠️ Partially correct' : '❌ Incorrect';
+          console.log(`${label}: ${evaluation.result.comment}`);
+        } else {
+          console.error(`  ❌ Failed to grade answer: ${evaluation.error}`);
+        }
+      }
       console.log(`Back: ${card.data.back}`);
       const quality = await select({
         message: 'How well did you recall this card?',

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,6 +4,7 @@ import { HTMLGenerator } from './external/publishers/html-generator.js';
 import { NodeMapper } from './adapters/node-mapper.js';
 import { HTTPCrawler } from './external/crawlers/http-crawler.js';
 import { OllamaFlashcardGenerator } from './external/ai-services/ollama-flashcard-generator.js';
+import { OllamaFlashcardAnswerGrader } from './external/ai-services/ollama-flashcard-answer-grader.js';
 import { CLI } from './external/cli/cli.js';
 import { CreateNodeUseCase } from './application/use-cases/create-node.js';
 import { GetNodeUseCase } from './application/use-cases/get-node.js';
@@ -13,6 +14,7 @@ import { SearchNodesUseCase } from './application/use-cases/search-nodes.js';
 import { GenerateFlashcardsUseCase } from './application/use-cases/generate-flashcards.js';
 import { GetDueFlashcardsUseCase } from './application/use-cases/get-due-flashcards.js';
 import { ReviewFlashcardUseCase } from './application/use-cases/review-flashcard.js';
+import { EvaluateFlashcardAnswerUseCase } from './application/use-cases/evaluate-flashcard-answer.js';
 
 class Application {
   private cli: CLI;
@@ -28,6 +30,7 @@ class Application {
     const htmlGenerator = new HTMLGenerator();
     const crawler = new HTTPCrawler();
     const flashcardGenerator = new OllamaFlashcardGenerator();
+    const flashcardAnswerGrader = new OllamaFlashcardAnswerGrader();
 
     const createNode = new CreateNodeUseCase(nodeRepository, crawler);
     const linkNodes = new LinkNodesUseCase(nodeRepository);
@@ -44,6 +47,9 @@ class Application {
     );
     const getDueFlashcards = new GetDueFlashcardsUseCase(nodeRepository);
     const reviewFlashcard = new ReviewFlashcardUseCase(nodeRepository);
+    const evaluateFlashcardAnswer = new EvaluateFlashcardAnswerUseCase(
+      flashcardAnswerGrader
+    );
     this.cli = new CLI(
       createNode,
       linkNodes,
@@ -52,7 +58,8 @@ class Application {
       generateFlashcards,
       publishSite,
       getDueFlashcards,
-      reviewFlashcard
+      reviewFlashcard,
+      evaluateFlashcardAnswer
     );
   }
 


### PR DESCRIPTION
## Summary
- add flashcard answer grading port and use case
- integrate Ollama-based flashcard answer grading
- update CLI review flow to collect answer and show grading feedback

## Testing
- `pnpm typecheck`
- `pnpm test --run`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68ac9584b460832ab8508afb4b1d3ee0