### PR TITLE
test: add generate flashcards use case tests

### DIFF
--- a/src/application/use-cases/generate-flashcards.integration.test.ts
+++ b/src/application/use-cases/generate-flashcards.integration.test.ts
@@ -1,0 +1,87 @@
+import { describe, test, beforeEach, afterEach, expect } from 'vitest';
+import { NodeMapper } from '../../adapters/node-mapper.js';
+import { SqliteNodeRepository } from '../../external/repositories/sqlite-node-repository.js';
+import { MockFlashcardGenerator } from '../../external/ai-services/mock-flashcard-generator.js';
+import { GenerateFlashcardsUseCase } from './generate-flashcards.js';
+import { NoteNode } from '../../domain/note-node.js';
+import { LinkNode } from '../../domain/link-node.js';
+import { TagNode } from '../../domain/tag-node.js';
+import { createTestDatabase, type TestDatabase } from '../../../test/database.js';
+import { assertOk } from '../../../test/assert.js';
+
+// Integration tests for GenerateFlashcardsUseCase
+
+describe('GenerateFlashcardsUseCase (integration)', () => {
+  let db: TestDatabase;
+  let repository: SqliteNodeRepository;
+  let generator: MockFlashcardGenerator;
+  let useCase: GenerateFlashcardsUseCase;
+
+  beforeEach(async () => {
+    db = await createTestDatabase();
+    repository = new SqliteNodeRepository(db, new NodeMapper());
+    generator = new MockFlashcardGenerator();
+    useCase = new GenerateFlashcardsUseCase(repository, generator);
+  });
+
+  afterEach(async () => {
+    await db.cleanup();
+  });
+
+  test('generates flashcards for note node', async () => {
+    const note = NoteNode.create({
+      title: 'Physics',
+      isPublic: false,
+      data: { content: 'Study of matter' },
+    });
+    await repository.save(note);
+
+    const result = await useCase.execute({ id: note.id });
+    assertOk(result);
+    expect(result.result).toHaveLength(3);
+  });
+
+  test('generates flashcards for link node', async () => {
+    const link = LinkNode.create({
+      title: 'CS Resource',
+      isPublic: false,
+      data: {
+        url: 'https://example.com',
+        crawled: {
+          title: 'CS',
+          text: 'Computer science resource',
+          html: '<p>CS</p>',
+        },
+      },
+    });
+    await repository.save(link);
+
+    const result = await useCase.execute({ id: link.id });
+    assertOk(result);
+    expect(result.result).toHaveLength(3);
+  });
+
+  test('returns error when node does not exist', async () => {
+    const result = await useCase.execute({ id: 'missing' });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBe('Node not found');
+    }
+  });
+
+  test('returns error for unsupported node type', async () => {
+    const tag = TagNode.create({
+      isPublic: false,
+      data: { name: 'tag' },
+    });
+    await repository.save(tag);
+
+    const result = await useCase.execute({ id: tag.id });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBe(
+        'Flashcards can be generated only from `note` or `link` node types'
+      );
+    }
+  });
+});

--- a/src/application/use-cases/generate-flashcards.test.ts
+++ b/src/application/use-cases/generate-flashcards.test.ts
@@ -1,0 +1,101 @@
+import { describe, test, expect, vi, beforeEach } from 'vitest';
+import { GenerateFlashcardsUseCase } from './generate-flashcards.js';
+import { NoteNode } from '../../domain/note-node.js';
+import { LinkNode } from '../../domain/link-node.js';
+import { TagNode } from '../../domain/tag-node.js';
+import type { NodeRepository } from '../ports/node-repository.js';
+import type { FlashcardGenerator, Flashcard } from '../ports/flashcard-generator.js';
+import { assertOk } from '../../../test/assert.js';
+
+// Unit tests for GenerateFlashcardsUseCase
+
+describe('GenerateFlashcardsUseCase', () => {
+  let repository: NodeRepository;
+  let generator: FlashcardGenerator;
+  let useCase: GenerateFlashcardsUseCase;
+
+  beforeEach(() => {
+    repository = {
+      findById: vi.fn(),
+    } as unknown as NodeRepository;
+    generator = {
+      generate: vi.fn(),
+    } as FlashcardGenerator;
+    useCase = new GenerateFlashcardsUseCase(repository, generator);
+  });
+
+  test('returns error when node not found', async () => {
+    vi.mocked(repository.findById).mockResolvedValue(null);
+
+    const result = await useCase.execute({ id: 'missing' });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBe('Node not found');
+    }
+  });
+
+  test('generates flashcards for note node', async () => {
+    const note = NoteNode.create({
+      title: 'Test Note',
+      isPublic: false,
+      data: { content: 'Content' },
+    });
+    const flashcards: Array<Flashcard> = [
+      { front: 'Q', back: 'A' },
+    ];
+    vi.mocked(repository.findById).mockResolvedValue(note);
+    vi.mocked(generator.generate).mockResolvedValue(flashcards);
+
+    const result = await useCase.execute({ id: note.id });
+    assertOk(result);
+    expect(result.result).toEqual(flashcards);
+    expect(generator.generate).toHaveBeenCalledWith('Test Note | Content');
+  });
+
+  test('generates flashcards for link node', async () => {
+    const link = LinkNode.create({
+      title: 'Example',
+      isPublic: false,
+      data: {
+        url: 'https://example.com',
+        crawled: { title: 'Example', text: 'Example text', html: '<p></p>' },
+      },
+    });
+    const flashcards: Array<Flashcard> = [
+      { front: 'LQ', back: 'LA' },
+    ];
+    vi.mocked(repository.findById).mockResolvedValue(link);
+    vi.mocked(generator.generate).mockResolvedValue(flashcards);
+
+    const result = await useCase.execute({ id: link.id });
+    assertOk(result);
+    expect(result.result).toEqual(flashcards);
+    expect(generator.generate).toHaveBeenCalledWith('Example | Example text');
+  });
+
+  test('returns error for unsupported node types', async () => {
+    const tag = TagNode.create({
+      isPublic: false,
+      data: { name: 'topic' },
+    });
+    vi.mocked(repository.findById).mockResolvedValue(tag);
+
+    const result = await useCase.execute({ id: tag.id });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBe(
+        'Flashcards can be generated only from `note` or `link` node types'
+      );
+    }
+  });
+
+  test('returns error when repository throws', async () => {
+    vi.mocked(repository.findById).mockRejectedValue(new Error('db error'));
+
+    const result = await useCase.execute({ id: 'id' });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBe('db error');
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for GenerateFlashcardsUseCase covering note, link, unsupported types and repository errors
- add integration tests using MockFlashcardGenerator

## Testing
- `pnpm test` *(fails: Cannot find module '../search-index/sqlite-search-index.js' in sqlite-node-repository.test.ts)*
- `pnpm test src/application/use-cases/generate-flashcards.test.ts src/application/use-cases/generate-flashcards.integration.test.ts --run`


------
https://chatgpt.com/codex/tasks/task_e_68aca3b2b018832abce9bd8b32144e79