### PR TITLE
feat: add cytoscape graph view

### DIFF
--- a/src/application/use-cases/publish-site.test.ts
+++ b/src/application/use-cases/publish-site.test.ts
@@ -64,7 +64,13 @@ describe('PublishSiteUseCase', () => {
     expect(result.ok).toBe(true);
 
     const files = await fs.readdir(outputDir);
-    expect(files.sort()).toEqual(['index.html', 'nodes', 'styles.css']);
+    expect(files.sort()).toEqual([
+      'graph-data.js',
+      'graph.html',
+      'index.html',
+      'nodes',
+      'styles.css',
+    ]);
 
     const nodeFiles = await fs.readdir(path.join(outputDir, 'nodes'));
     expect(nodeFiles).toEqual([`${publicNote.id}.html`]);
@@ -240,7 +246,12 @@ describe('PublishSiteUseCase', () => {
     await useCase.execute();
 
     const files = await fs.readdir(outputDir);
-    expect(files.sort()).toEqual(['index.html', 'styles.css']);
+    expect(files.sort()).toEqual([
+      'graph-data.js',
+      'graph.html',
+      'index.html',
+      'styles.css',
+    ]);
 
     const index = await fs.readFile(path.join(outputDir, 'index.html'), 'utf8');
     expect(index).toContain('0 nodes published');

--- a/src/application/use-cases/publish-site.ts
+++ b/src/application/use-cases/publish-site.ts
@@ -16,8 +16,15 @@ class PublishSiteUseCase {
       const allNodes = await this.repository.findAll();
       const publicNodes = allNodes.filter((n) => n.isPublic);
 
+      // Load relations for each public node
+      const nodesWithRelations: typeof publicNodes = [];
+      for (const node of publicNodes) {
+        const withRelations = await this.repository.findById(node.id, true);
+        nodesWithRelations.push(withRelations ?? node);
+      }
+
       // Generate site files
-      const siteFiles = await this.siteGenerator.generate(publicNodes);
+      const siteFiles = await this.siteGenerator.generate(nodesWithRelations);
 
       // Ensure output directory exists
       await fs.mkdir(this.outputDir, { recursive: true });


### PR DESCRIPTION
## Summary
- generate Cytoscape-based graph view and link from index
- load node relations when publishing site
- cover new graph assets in publish tests

## Testing
- `pnpm typecheck`
- `pnpm test --run`
- `pnpm build`
- `pnpm site:build` *(fails: Failed query: select "id", "type"...)*

------
https://chatgpt.com/codex/tasks/task_e_68ab335e4e54832a8d354fdc31b13875