### PR TITLE
refactor: use Result type across use cases

### DIFF
--- a/src/application/use-cases/create-node.integration.test.ts
+++ b/src/application/use-cases/create-node.integration.test.ts
@@ -43,7 +43,7 @@ describe('CreateNodeUseCase (integration)', () => {
 
     assertOk(result);
 
-    const stored = await repository.findById(result.result.id);
+    const stored = await repository.findById(result.value.node.id);
     expect(stored?.title).toBe('Integration Note');
   });
 
@@ -56,8 +56,8 @@ describe('CreateNodeUseCase (integration)', () => {
 
     assertOk(result);
 
-    const stored = await repository.findById(result.result.id);
-    expect(stored?.id).toBe(result.result.id);
+    const stored = await repository.findById(result.value.node.id);
+    expect(stored?.id).toBe(result.value.node.id);
     if (stored && stored.type === 'link') {
       expect(stored.data.crawled.title).toBe('Example');
     } else {

--- a/src/application/use-cases/create-node.test.ts
+++ b/src/application/use-cases/create-node.test.ts
@@ -26,8 +26,8 @@ describe('CreateNodeUseCase', () => {
       isPublic: false,
     });
     assertOk(result);
-    expect(result.result.type).toBe('note');
-    expect(repository.save).toHaveBeenCalledWith(result.result);
+    expect(result.value.node.type).toBe('note');
+    expect(repository.save).toHaveBeenCalledWith(result.value.node);
   });
 
   test('creates a link node using crawler data', async () => {
@@ -47,8 +47,8 @@ describe('CreateNodeUseCase', () => {
 
     assertOk(result);
     expect(crawler.fetch).toHaveBeenCalledWith('https://example.com');
-    expect(result.result.type).toBe('link');
-    expect(repository.save).toHaveBeenCalledWith(result.result);
+    expect(result.value.node.type).toBe('link');
+    expect(repository.save).toHaveBeenCalledWith(result.value.node);
   });
 
   test('creates a tag node', async () => {
@@ -58,8 +58,8 @@ describe('CreateNodeUseCase', () => {
       data: { name: 'math', description: 'numbers' },
     });
     assertOk(result);
-    expect(result.result.type).toBe('tag');
-    expect(repository.save).toHaveBeenCalledWith(result.result);
+    expect(result.value.node.type).toBe('tag');
+    expect(repository.save).toHaveBeenCalledWith(result.value.node);
   });
 
   test('creates a flashcard node', async () => {
@@ -69,8 +69,8 @@ describe('CreateNodeUseCase', () => {
       data: { front: '2+2', back: '4' },
     });
     assertOk(result);
-    expect(result.result.type).toBe('flashcard');
-    expect(repository.save).toHaveBeenCalledWith(result.result);
+    expect(result.value.node.type).toBe('flashcard');
+    expect(repository.save).toHaveBeenCalledWith(result.value.node);
   });
 
   test('returns error when repository throws', async () => {

--- a/src/application/use-cases/evaluate-flashcard-answer.test.ts
+++ b/src/application/use-cases/evaluate-flashcard-answer.test.ts
@@ -29,7 +29,7 @@ describe('EvaluateFlashcardAnswerUseCase', () => {
     const result = await useCase.execute(input);
 
     assertOk(result);
-    expect(result.result).toBe(evaluation);
+    expect(result.value).toBe(evaluation);
     expect(grader.evaluate).toHaveBeenCalledWith(input);
   });
 
@@ -44,7 +44,7 @@ describe('EvaluateFlashcardAnswerUseCase', () => {
 
     expect(result.ok).toBe(false);
     if (!result.ok) {
-      expect(result.error).toBe('fail');
+      expect(result.error.message).toBe('fail');
     }
   });
 });

--- a/src/application/use-cases/evaluate-flashcard-answer.ts
+++ b/src/application/use-cases/evaluate-flashcard-answer.ts
@@ -2,6 +2,7 @@ import type {
   FlashcardAnswerGrader,
   FlashcardAnswerEvaluation,
 } from '../ports/flashcard-answer-grader.js';
+import { Result } from '../../shared/result.js';
 
 class EvaluateFlashcardAnswerUseCase {
   constructor(private readonly grader: FlashcardAnswerGrader) {}
@@ -10,14 +11,14 @@ class EvaluateFlashcardAnswerUseCase {
     front: string;
     back: string;
     answer: string;
-  }): Promise<
-    { ok: true; result: FlashcardAnswerEvaluation } | { ok: false; error: string }
-  > {
+  }): Promise<Result<FlashcardAnswerEvaluation, Error>> {
     try {
       const evaluation = await this.grader.evaluate(input);
-      return { ok: true, result: evaluation };
+      return Result.success(evaluation);
     } catch (err) {
-      return { ok: false, error: (err as Error).message };
+      return Result.failure(
+        err instanceof Error ? err : new Error(String(err))
+      );
     }
   }
 }

--- a/src/application/use-cases/generate-flashcards.integration.test.ts
+++ b/src/application/use-cases/generate-flashcards.integration.test.ts
@@ -38,7 +38,7 @@ describe('GenerateFlashcardsUseCase (integration)', () => {
 
     const result = await useCase.execute({ id: note.id });
     assertOk(result);
-    expect(result.result).toHaveLength(3);
+    expect(result.value).toHaveLength(3);
   });
 
   test('generates flashcards for link node', async () => {
@@ -58,14 +58,14 @@ describe('GenerateFlashcardsUseCase (integration)', () => {
 
     const result = await useCase.execute({ id: link.id });
     assertOk(result);
-    expect(result.result).toHaveLength(3);
+    expect(result.value).toHaveLength(3);
   });
 
   test('returns error when node does not exist', async () => {
     const result = await useCase.execute({ id: 'missing' });
     expect(result.ok).toBe(false);
     if (!result.ok) {
-      expect(result.error).toBe('Node not found');
+      expect(result.error.message).toBe('Node not found');
     }
   });
 
@@ -79,7 +79,7 @@ describe('GenerateFlashcardsUseCase (integration)', () => {
     const result = await useCase.execute({ id: tag.id });
     expect(result.ok).toBe(false);
     if (!result.ok) {
-      expect(result.error).toBe(
+      expect(result.error.message).toBe(
         'Flashcards can be generated only from `note` or `link` node types'
       );
     }

--- a/src/application/use-cases/generate-flashcards.test.ts
+++ b/src/application/use-cases/generate-flashcards.test.ts
@@ -30,7 +30,7 @@ describe('GenerateFlashcardsUseCase', () => {
     const result = await useCase.execute({ id: 'missing' });
     expect(result.ok).toBe(false);
     if (!result.ok) {
-      expect(result.error).toBe('Node not found');
+      expect(result.error.message).toBe('Node not found');
     }
   });
 
@@ -48,7 +48,7 @@ describe('GenerateFlashcardsUseCase', () => {
 
     const result = await useCase.execute({ id: note.id });
     assertOk(result);
-    expect(result.result).toEqual(flashcards);
+    expect(result.value).toEqual(flashcards);
     expect(generator.generate).toHaveBeenCalledWith('Test Note | Content');
   });
 
@@ -69,7 +69,7 @@ describe('GenerateFlashcardsUseCase', () => {
 
     const result = await useCase.execute({ id: link.id });
     assertOk(result);
-    expect(result.result).toEqual(flashcards);
+    expect(result.value).toEqual(flashcards);
     expect(generator.generate).toHaveBeenCalledWith('Example | Example text');
   });
 
@@ -83,7 +83,7 @@ describe('GenerateFlashcardsUseCase', () => {
     const result = await useCase.execute({ id: tag.id });
     expect(result.ok).toBe(false);
     if (!result.ok) {
-      expect(result.error).toBe(
+      expect(result.error.message).toBe(
         'Flashcards can be generated only from `note` or `link` node types'
       );
     }
@@ -95,7 +95,7 @@ describe('GenerateFlashcardsUseCase', () => {
     const result = await useCase.execute({ id: 'id' });
     expect(result.ok).toBe(false);
     if (!result.ok) {
-      expect(result.error).toBe('db error');
+      expect(result.error.message).toBe('db error');
     }
   });
 });

--- a/src/application/use-cases/get-due-flashcards.ts
+++ b/src/application/use-cases/get-due-flashcards.ts
@@ -1,5 +1,6 @@
 import type { NodeRepository } from '../ports/node-repository.js';
 import type { FlashcardNode } from '../../domain/flashcard-node.js';
+import { Result } from '../../shared/result.js';
 
 class GetDueFlashcardsUseCase {
   constructor(private readonly repository: NodeRepository) {}
@@ -7,17 +8,17 @@ class GetDueFlashcardsUseCase {
   async execute(input: {
     limit: number;
     date?: Date;
-  }): Promise<
-    { ok: true; result: FlashcardNode[] } | { ok: false; error: string }
-  > {
+  }): Promise<Result<FlashcardNode[], Error>> {
     try {
       const cards = await this.repository.findDueFlashcards(
         input.date ?? new Date(),
         input.limit
       );
-      return { ok: true, result: cards };
+      return Result.success(cards);
     } catch (err) {
-      return { ok: false, error: (err as Error).message };
+      return Result.failure(
+        err instanceof Error ? err : new Error(String(err))
+      );
     }
   }
 }

--- a/src/application/use-cases/get-node.integration.test.ts
+++ b/src/application/use-cases/get-node.integration.test.ts
@@ -32,14 +32,14 @@ describe('GetNodeUseCase (integration)', () => {
 
     const result = await useCase.execute({ id: note.id });
     assertOk(result);
-    expect(result.result.id).toBe(note.id);
+    expect(result.value.id).toBe(note.id);
   });
 
   test('returns error when node does not exist', async () => {
     const result = await useCase.execute({ id: randomUUID() });
     expect(result.ok).toBe(false);
     if (!result.ok) {
-      expect(result.error).toBe('Node not found');
+      expect(result.error.message).toBe('Node not found');
     }
   });
 
@@ -60,6 +60,6 @@ describe('GetNodeUseCase (integration)', () => {
 
     const result = await useCase.execute({ id: parent.id });
     assertOk(result);
-    expect(result.result.relatedNodes).toHaveLength(0);
+    expect(result.value.relatedNodes).toHaveLength(0);
   });
 });

--- a/src/application/use-cases/get-node.test.ts
+++ b/src/application/use-cases/get-node.test.ts
@@ -25,7 +25,7 @@ describe('GetNodeUseCase', () => {
 
     const result = await useCase.execute({ id: note.id });
     assertOk(result);
-    expect(result.result).toBe(note);
+    expect(result.value).toBe(note);
     expect(repository.findById).toHaveBeenCalledWith(note.id, false);
   });
 
@@ -35,7 +35,7 @@ describe('GetNodeUseCase', () => {
     const result = await useCase.execute({ id: 'missing' });
     expect(result.ok).toBe(false);
     if (!result.ok) {
-      expect(result.error).toBe('Node not found');
+      expect(result.error.message).toBe('Node not found');
     }
   });
 
@@ -45,7 +45,7 @@ describe('GetNodeUseCase', () => {
     const result = await useCase.execute({ id: 'x' });
     expect(result.ok).toBe(false);
     if (!result.ok) {
-      expect(result.error).toBe('db error');
+      expect(result.error.message).toBe('db error');
     }
   });
 });

--- a/src/application/use-cases/get-node.ts
+++ b/src/application/use-cases/get-node.ts
@@ -1,5 +1,6 @@
 import type { AnyNode } from '../../domain/types.js';
 import type { NodeRepository } from '../ports/node-repository.js';
+import { Result } from '../../shared/result.js';
 
 type GetNodeInput = {
   id: string;
@@ -8,17 +9,17 @@ type GetNodeInput = {
 class GetNodeUseCase {
   constructor(private readonly repository: NodeRepository) {}
 
-  async execute(
-    input: GetNodeInput
-  ): Promise<{ ok: true; result: AnyNode } | { ok: false; error: string }> {
+  async execute(input: GetNodeInput): Promise<Result<AnyNode, Error>> {
     try {
       const result = await this.repository.findById(input.id, false);
       if (!result) {
-        return { ok: false, error: 'Node not found' };
+        return Result.failure(new Error('Node not found'));
       }
-      return { ok: true, result };
+      return Result.success(result);
     } catch (err) {
-      return { ok: false, error: (err as Error).message };
+      return Result.failure(
+        err instanceof Error ? err : new Error(String(err))
+      );
     }
   }
 }

--- a/src/application/use-cases/link-nodes.ts
+++ b/src/application/use-cases/link-nodes.ts
@@ -1,5 +1,6 @@
 import type { EdgeType } from '../../domain/types.js';
 import type { NodeRepository } from '../ports/node-repository.js';
+import { Result } from '../../shared/result.js';
 
 type LinkNodesInput = {
   fromId: string;
@@ -11,7 +12,7 @@ type LinkNodesInput = {
 class LinkNodesUseCase {
   constructor(private readonly repository: NodeRepository) {}
 
-  async execute(input: LinkNodesInput) {
+  async execute(input: LinkNodesInput): Promise<Result<void, Error>> {
     try {
       await this.repository.link(
         input.fromId,
@@ -19,9 +20,11 @@ class LinkNodesUseCase {
         input.type,
         input.isBidirectional
       );
-      return { ok: true as const };
+      return Result.success(undefined);
     } catch (err) {
-      return { ok: false as const, error: (err as Error).message };
+      return Result.failure(
+        err instanceof Error ? err : new Error(String(err))
+      );
     }
   }
 }

--- a/src/application/use-cases/review-flashcard.ts
+++ b/src/application/use-cases/review-flashcard.ts
@@ -1,5 +1,6 @@
 import type { NodeRepository } from '../ports/node-repository.js';
 import type { FlashcardNode } from '../../domain/flashcard-node.js';
+import { Result } from '../../shared/result.js';
 
 class ReviewFlashcardUseCase {
   constructor(private readonly repository: NodeRepository) {}
@@ -7,15 +8,15 @@ class ReviewFlashcardUseCase {
   async execute(input: {
     flashcard: FlashcardNode;
     quality: number;
-  }): Promise<
-    { ok: true; result: FlashcardNode } | { ok: false; error: string }
-  > {
+  }): Promise<Result<FlashcardNode, Error>> {
     try {
       const updated = input.flashcard.review(input.quality);
       await this.repository.update(updated);
-      return { ok: true, result: updated };
+      return Result.success(updated);
     } catch (err) {
-      return { ok: false, error: (err as Error).message };
+      return Result.failure(
+        err instanceof Error ? err : new Error(String(err))
+      );
     }
   }
 }

--- a/src/application/use-cases/search-nodes.integration.test.ts
+++ b/src/application/use-cases/search-nodes.integration.test.ts
@@ -38,7 +38,7 @@ describe('SearchNodesUseCase (integration)', () => {
 
     const result = await useCase.execute({ query: 'important' });
     assertOk(result);
-    const hit = first(result.result);
+    const hit = first(result.value);
     expect(hit.node.id).toBe(note.id);
   });
 
@@ -62,8 +62,8 @@ describe('SearchNodesUseCase (integration)', () => {
 
     const result = await useCase.execute({ query: 'computer' });
     assertOk(result);
-    expect(result.result).toHaveLength(2);
-    const types = result.result.map((r) => r.node.type).sort();
+    expect(result.value).toHaveLength(2);
+    const types = result.value.map((r) => r.node.type).sort();
     expect(types).toEqual(['link', 'note']);
   });
 
@@ -84,7 +84,7 @@ describe('SearchNodesUseCase (integration)', () => {
 
     const result = await useCase.execute({ query: 'Parent', withRelations: true });
     assertOk(result);
-    const hit = first(result.result);
+    const hit = first(result.value);
     const related = first(hit.node.relatedNodes);
     expect(related.node.id).toBe(child.id);
   });
@@ -99,6 +99,6 @@ describe('SearchNodesUseCase (integration)', () => {
 
     const result = await useCase.execute({ query: 'unrelated' });
     assertOk(result);
-    expect(result.result).toEqual([]);
+    expect(result.value).toEqual([]);
   });
 });

--- a/src/application/use-cases/search-nodes.test.ts
+++ b/src/application/use-cases/search-nodes.test.ts
@@ -18,7 +18,7 @@ describe('SearchNodesUseCase', () => {
   test('returns empty results for blank query without calling repository', async () => {
     const result = await useCase.execute({ query: '   ' });
     assertOk(result);
-    expect(result.result).toEqual([]);
+    expect(result.value).toEqual([]);
     expect(repository.search).not.toHaveBeenCalled();
   });
 
@@ -35,7 +35,7 @@ describe('SearchNodesUseCase', () => {
 
     const result = await useCase.execute({ query: 'content' });
     assertOk(result);
-    expect(result.result).toEqual(mockResults);
+    expect(result.value).toEqual(mockResults);
     expect(repository.search).toHaveBeenCalledWith('content', undefined);
   });
 
@@ -53,7 +53,7 @@ describe('SearchNodesUseCase', () => {
     const result = await useCase.execute({ query: 'test' });
     expect(result.ok).toBe(false);
     if (!result.ok) {
-      expect(result.error).toBe('db error');
+      expect(result.error.message).toBe('db error');
     }
   });
 });

--- a/src/application/use-cases/search-nodes.ts
+++ b/src/application/use-cases/search-nodes.ts
@@ -1,4 +1,5 @@
 import type { NodeRepository, SearchResult } from '../ports/node-repository.js';
+import { Result } from '../../shared/result.js';
 
 type SearchNodesInput = {
   query: string;
@@ -10,11 +11,9 @@ class SearchNodesUseCase {
 
   async execute(
     input: SearchNodesInput
-  ): Promise<
-    { ok: true; result: Array<SearchResult> } | { ok: false; error: string }
-  > {
+  ): Promise<Result<Array<SearchResult>, Error>> {
     if (!input.query.trim()) {
-      return { ok: true, result: [] };
+      return Result.success([]);
     }
 
     try {
@@ -22,9 +21,11 @@ class SearchNodesUseCase {
         input.query,
         input.withRelations
       );
-      return { ok: true, result };
+      return Result.success(result);
     } catch (err) {
-      return { ok: false, error: (err as Error).message };
+      return Result.failure(
+        err instanceof Error ? err : new Error(String(err))
+      );
     }
   }
 }

--- a/src/external/cli/commands/create.ts
+++ b/src/external/cli/commands/create.ts
@@ -71,11 +71,11 @@ class CreateCommand {
 
       if (result && result.ok) {
         console.log(
-          `✅ Created ${nodeType} node with ID: ${result.result.node.id}`
+          `✅ Created ${nodeType} node with ID: ${result.value.node.id}`
         );
 
-        if (result.result.warning) {
-          console.warn(`⚠️  ${result.result.warning}`);
+        if (result.value.warning) {
+          console.warn(`⚠️  ${result.value.warning}`);
         }
 
         const shouldLink = await confirm({
@@ -84,10 +84,10 @@ class CreateCommand {
         });
 
         if (shouldLink) {
-          await this.linkNode(result.result.node.id);
+          await this.linkNode(result.value.node.id);
         }
       } else {
-        console.error(`❌ Error creating node: ${result.error}`);
+        console.error(`❌ Error creating node: ${result.error.message}`);
         process.exit(1);
       }
     } catch (error) {
@@ -213,7 +213,7 @@ class CreateCommand {
           });
           if (!linkResult.ok) {
             console.error(
-              `❌ Error linking to node ${targetNodeId}: ${linkResult.error}`
+              `❌ Error linking to node ${targetNodeId}: ${linkResult.error.message}`
             );
           }
         }

--- a/src/external/cli/commands/generate-flashcards.ts
+++ b/src/external/cli/commands/generate-flashcards.ts
@@ -34,11 +34,11 @@ class GenerateFlashcardsCommand {
     });
 
     if (!result.ok) {
-      console.error(`❌ Error generating flashcards: ${result.error}`);
+      console.error(`❌ Error generating flashcards: ${result.error.message}`);
       process.exit(1);
     }
 
-    const flashcards = result.result;
+    const flashcards = result.value;
 
     if (flashcards.length === 0) {
       console.log('No flashcards were generated.');
@@ -74,9 +74,11 @@ class GenerateFlashcardsCommand {
         isPublic: makePublic,
       });
       if (saveResult.ok) {
-        createdIds.push(saveResult.result.node.id);
+        createdIds.push(saveResult.value.node.id);
       } else {
-        console.error(`  ❌ Failed to save a flashcard: ${saveResult.error}`);
+        console.error(
+          `  ❌ Failed to save a flashcard: ${saveResult.error.message}`
+        );
       }
     }
 
@@ -90,7 +92,7 @@ class GenerateFlashcardsCommand {
         isBidirectional: true,
       });
       if (!linkRes.ok) {
-        console.error(`  ❌ Failed to link ${id}: ${linkRes.error}`);
+        console.error(`  ❌ Failed to link ${id}: ${linkRes.error.message}`);
       }
     }
     console.log(

--- a/src/external/cli/commands/publish.ts
+++ b/src/external/cli/commands/publish.ts
@@ -21,10 +21,10 @@ class PublishCommand {
 
       if (result.ok) {
         console.log(
-          `✅ Successfully published ${result.result.filesGenerated} files to ${result.result.outputDir}`
+          `✅ Successfully published ${result.value.filesGenerated} files to ${result.value.outputDir}`
         );
       } else {
-        console.error(`❌ Error publishing site: ${result.error}`);
+        console.error(`❌ Error publishing site: ${result.error.message}`);
         process.exit(1);
       }
     } catch (error) {

--- a/src/external/cli/commands/review.ts
+++ b/src/external/cli/commands/review.ts
@@ -24,10 +24,10 @@ class ReviewCommand {
     console.log('\n🔁 Reviewing due flashcards...\n');
     const result = await this.getDueFlashcardsUseCase.execute({ limit: 20 });
     if (!result.ok) {
-      console.error(`❌ Error fetching flashcards: ${result.error}`);
+      console.error(`❌ Error fetching flashcards: ${result.error.message}`);
       return;
     }
-    const cards = result.result;
+    const cards = result.value;
     if (cards.length === 0) {
       console.log('No flashcards are due for review.');
       return;
@@ -46,12 +46,12 @@ class ReviewCommand {
           answer,
         });
         if (evaluation.ok) {
-          const score = evaluation.result.score;
+          const score = evaluation.value.score;
           const label =
             score === 1 ? '✅ Correct' : score === 0.5 ? '⚠️ Partially correct' : '❌ Incorrect';
-          console.log(`${label}: ${evaluation.result.comment}`);
+          console.log(`${label}: ${evaluation.value.comment}`);
         } else {
-          console.error(`  ❌ Failed to grade answer: ${evaluation.error}`);
+          console.error(`  ❌ Failed to grade answer: ${evaluation.error.message}`);
         }
       }
       console.log(`Back: ${card.data.back}`);
@@ -69,7 +69,7 @@ class ReviewCommand {
         quality,
       });
       if (!review.ok) {
-        console.error(`  ❌ Failed to review card: ${review.error}`);
+        console.error(`  ❌ Failed to review card: ${review.error.message}`);
       }
     }
 

--- a/src/external/cli/commands/search.ts
+++ b/src/external/cli/commands/search.ts
@@ -65,13 +65,13 @@ class SearchCommand {
     const result = await this.getNodeUseCase.execute({ id: nodeId });
 
     if (!result.ok) {
-      console.error(`❌ Error fetching node: ${result.error}`);
+      console.error(`❌ Error fetching node: ${result.error.message}`);
       process.exit(1);
     }
 
     await editor({
       message: 'Read only node was displayed in the editor',
-      default: JSON.stringify(result.result, undefined, 2),
+      default: JSON.stringify(result.value, undefined, 2),
       waitForUseInput: false,
     });
   }

--- a/src/external/cli/prompts/search.ts
+++ b/src/external/cli/prompts/search.ts
@@ -45,13 +45,13 @@ async function searchPrompt(
       if (!result.ok) {
         return [
           {
-            name: `Error: ${result.error}`,
+            name: `Error: ${result.error.message}`,
             value: '',
             disabled: true,
           },
         ];
       }
-      let results = result.result;
+      let results = result.value;
       if (options?.filterResults) {
         results = options.filterResults(results);
       }

--- a/test/assert.ts
+++ b/test/assert.ts
@@ -3,7 +3,7 @@ import { Result } from '../src/shared/result';
 
 function assertOk<T>(
   result: Result<T, Error>
-): asserts result is { ok: true; result: T } {
+): asserts result is { ok: true; value: T } {
   expect(result.ok).toBe(true);
   if (!result.ok) throw new Error(result.error.message);
 }


### PR DESCRIPTION
## Summary
- refactor use cases to return shared Result objects
- align CLI with Result `value`/`error` structure
- update tests to match new Result API

## Testing
- `pnpm test run`
- `pnpm typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68af12a6c4bc832a8f09bafd9991e646