### PR TITLE
test: add crawler fetch failure test

### DIFF
--- a/src/application/use-cases/create-node.test.ts
+++ b/src/application/use-cases/create-node.test.ts
@@ -88,4 +88,19 @@ describe('CreateNodeUseCase', () => {
       expect(result.error).toBeInstanceOf(Error);
     }
   });
+
+  test('returns error when crawler fetch fails', async () => {
+    vi.mocked(crawler.fetch).mockRejectedValue(new Error('fetch fail'));
+
+    const result = await useCase.execute({
+      type: 'link',
+      data: { url: 'https://example.com' },
+      isPublic: true,
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.message).toBe('fetch fail');
+    }
+  });
 });


### PR DESCRIPTION
## Summary
- add test for CreateNodeUseCase when crawler.fetch rejects

## Testing
- `pnpm test src/application/use-cases/create-node.test.ts` *(fails: expected true to be false)*

------
https://chatgpt.com/codex/tasks/task_e_68af253cc604832a8943b1b22288db95