### PR TITLE
test: ensure crawler unused for non-link nodes

### DIFF
--- a/src/application/use-cases/create-node.test.ts
+++ b/src/application/use-cases/create-node.test.ts
@@ -28,6 +28,7 @@ describe('CreateNodeUseCase', () => {
     assertOk(result);
     expect(result.value.node.type).toBe('note');
     expect(repository.save).toHaveBeenCalledWith(result.value.node);
+    expect(crawler.fetch).not.toHaveBeenCalled();
   });
 
   test('creates a link node using crawler data', async () => {
@@ -60,6 +61,7 @@ describe('CreateNodeUseCase', () => {
     assertOk(result);
     expect(result.value.node.type).toBe('tag');
     expect(repository.save).toHaveBeenCalledWith(result.value.node);
+    expect(crawler.fetch).not.toHaveBeenCalled();
   });
 
   test('creates a flashcard node', async () => {
@@ -71,6 +73,7 @@ describe('CreateNodeUseCase', () => {
     assertOk(result);
     expect(result.value.node.type).toBe('flashcard');
     expect(repository.save).toHaveBeenCalledWith(result.value.node);
+    expect(crawler.fetch).not.toHaveBeenCalled();
   });
 
   test('returns error when repository throws', async () => {


### PR DESCRIPTION
## Summary
- add assertions ensuring `crawler.fetch` isn't called when creating note, tag, or flashcard nodes

## Testing
- `pnpm test --run`

------
https://chatgpt.com/codex/tasks/task_e_68af2547a440832a90dfffd50deed323