### PR TITLE
test: add create-node tag and flashcard integration tests

### DIFF
--- a/src/application/use-cases/create-node.integration.test.ts
+++ b/src/application/use-cases/create-node.integration.test.ts
@@ -64,4 +64,34 @@ describe('CreateNodeUseCase (integration)', () => {
       throw new Error('expected link node');
     }
   });
+
+  test('persists a tag node', async () => {
+    const input = {
+      type: 'tag',
+      isPublic: false,
+      data: { name: 'integration-tag', description: 'test tag' },
+    };
+
+    const result = await useCase.execute(input);
+
+    assertOk(result);
+
+    const stored = await repository.findById(result.value.node.id);
+    expect(stored).toStrictEqual(result.value.node);
+  });
+
+  test('persists a flashcard node', async () => {
+    const input = {
+      type: 'flashcard',
+      isPublic: true,
+      data: { front: 'front', back: 'back' },
+    };
+
+    const result = await useCase.execute(input);
+
+    assertOk(result);
+
+    const stored = await repository.findById(result.value.node.id);
+    expect(stored).toStrictEqual(result.value.node);
+  });
 });


### PR DESCRIPTION
## Summary
- expand CreateNode integration tests to cover tag nodes
- add flashcard node integration test verifying storage integrity

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68af25362d04832abdfe563ffe39ebf0