### PR TITLE
feat: improve review card spacing

### DIFF
--- a/src/external/cli/commands/review.ts
+++ b/src/external/cli/commands/review.ts
@@ -34,6 +34,7 @@ class ReviewCommand {
     for (const [i, card] of cards.entries()) {
       console.log(`\n📚 Card ${i + 1} of ${cards.length}`);
       console.log(`Front: ${card.data.front}`);
+      console.log();
       const answer = await input({
         message: 'Type your answer:',
       });
@@ -53,7 +54,10 @@ class ReviewCommand {
       } else {
         console.error(`  ❌ Failed to review card: ${review.error.message}`);
       }
+      console.log();
+      console.log('─'.repeat(50));
       console.log(`Back: ${card.data.back}`);
+      console.log();
     }
 
     console.log('\n✅ Review session complete');


### PR DESCRIPTION
## Summary
- space review prompt with blank line before answer input
- separate grading from back text with a line and separator
- add extra newline after showing card back for visual separation

## Testing
- `pnpm test --run`

------
https://chatgpt.com/codex/tasks/task_e_68af2a115180832a82971961359d0b97